### PR TITLE
Add ConfirmationDialog#style

### DIFF
--- a/lib/slack/block_kit/composition/confirmation_dialog.rb
+++ b/lib/slack/block_kit/composition/confirmation_dialog.rb
@@ -15,8 +15,9 @@ module Slack
           self
         end
 
-        def confirm(text:, emoji: nil)
+        def confirm(text:, emoji: nil, style: nil)
           @confirm = PlainText.new(text: text, emoji: emoji)
+          @style = style
 
           self
         end
@@ -44,8 +45,9 @@ module Slack
             title: @title.as_json,
             text: @text.as_json,
             confirm: @confirm.as_json,
-            deny: @deny.as_json
-          }
+            deny: @deny.as_json,
+            style: @style
+          }.compact
         end
       end
     end

--- a/lib/slack/block_kit/composition/confirmation_dialog.rb
+++ b/lib/slack/block_kit/composition/confirmation_dialog.rb
@@ -15,9 +15,8 @@ module Slack
           self
         end
 
-        def confirm(text:, emoji: nil, style: nil)
+        def confirm(text:, emoji: nil)
           @confirm = PlainText.new(text: text, emoji: emoji)
-          @style = style
 
           self
         end

--- a/lib/slack/block_kit/composition/confirmation_dialog.rb
+++ b/lib/slack/block_kit/composition/confirmation_dialog.rb
@@ -34,6 +34,12 @@ module Slack
           self
         end
 
+        def style(value)
+          @style = value
+
+          self
+        end
+
         def mrkdwn(text:, verbatim: nil)
           @text = Mrkdwn.new(text: text, verbatim: verbatim)
 

--- a/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
+++ b/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
@@ -80,5 +80,24 @@ RSpec.describe Slack::BlockKit::Composition::ConfirmationDialog do
         expect(instance.as_json).to eq(expected)
       end
     end
+
+    context 'when style is set' do
+      it 'correctly serializes' do
+        instance.title(text: 'title')
+        instance.confirm(text: 'confirm', style: 'danger')
+        instance.deny(text: 'deny')
+        instance.plain_text(text: 'plain_text')
+
+        expected = {
+          title: Slack::BlockKit::Composition::PlainText.new(text: 'title').as_json,
+          deny: Slack::BlockKit::Composition::PlainText.new(text: 'deny').as_json,
+          confirm: Slack::BlockKit::Composition::PlainText.new(text: 'confirm').as_json,
+          text: Slack::BlockKit::Composition::PlainText.new(text: 'plain_text').as_json,
+          style: 'danger'
+        }
+
+        expect(instance.as_json).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
+++ b/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
@@ -108,24 +108,5 @@ RSpec.describe Slack::BlockKit::Composition::ConfirmationDialog do
         expect(instance.as_json).to eq(expected)
       end
     end
-
-    context 'when style is passed to confirm method' do
-      it 'correctly serializes' do
-        instance.title(text: 'title')
-        instance.confirm(text: 'confirm', style: 'danger')
-        instance.deny(text: 'deny')
-        instance.plain_text(text: 'plain_text')
-
-        expected = {
-          title: Slack::BlockKit::Composition::PlainText.new(text: 'title').as_json,
-          deny: Slack::BlockKit::Composition::PlainText.new(text: 'deny').as_json,
-          confirm: Slack::BlockKit::Composition::PlainText.new(text: 'confirm').as_json,
-          text: Slack::BlockKit::Composition::PlainText.new(text: 'plain_text').as_json,
-          style: 'danger'
-        }
-
-        expect(instance.as_json).to eq(expected)
-      end
-    end
   end
 end

--- a/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
+++ b/spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Slack::BlockKit::Composition::ConfirmationDialog do
     end
   end
 
+  describe '#style' do
+    it 'sets @style as PlainText'
+
+    it 'returns self' do
+      expect(instance.style('danger')).to be(instance)
+    end
+  end
+
   describe '#plain_text' do
     it 'sets @text as PlainText'
 
@@ -82,6 +90,26 @@ RSpec.describe Slack::BlockKit::Composition::ConfirmationDialog do
     end
 
     context 'when style is set' do
+      it 'correctly serializes' do
+        instance.title(text: 'title')
+        instance.confirm(text: 'confirm')
+        instance.deny(text: 'deny')
+        instance.plain_text(text: 'plain_text')
+        instance.style('danger')
+
+        expected = {
+          title: Slack::BlockKit::Composition::PlainText.new(text: 'title').as_json,
+          deny: Slack::BlockKit::Composition::PlainText.new(text: 'deny').as_json,
+          confirm: Slack::BlockKit::Composition::PlainText.new(text: 'confirm').as_json,
+          text: Slack::BlockKit::Composition::PlainText.new(text: 'plain_text').as_json,
+          style: 'danger'
+        }
+
+        expect(instance.as_json).to eq(expected)
+      end
+    end
+
+    context 'when style is passed to confirm method' do
       it 'correctly serializes' do
         instance.title(text: 'title')
         instance.confirm(text: 'confirm', style: 'danger')


### PR DESCRIPTION
Confirmation dialog object supports `style` field to specify color schema of `confirm` button as per the official API doc (https://api.slack.com/reference/block-kit/composition-objects#option#confirm). 

For reference, [here is a minimal example](https://api.slack.com/tools/block-kit-builder?mode=message&blocks=%5B%7B%22type%22%3A%22actions%22%2C%22elements%22%3A%5B%7B%22type%22%3A%22button%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22emoji%22%3Atrue%2C%22text%22%3A%22Approve%22%7D%2C%22confirm%22%3A%7B%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Are%20you%20sure%3F%22%7D%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22Wouldn%27t%20you%20prefer%20a%20good%20game%20of%20_chess_%3F%22%7D%2C%22confirm%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Do%20it%22%7D%2C%22deny%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Stop%2C%20I%27ve%20changed%20my%20mind!%22%7D%2C%22style%22%3A%22danger%22%7D%2C%22value%22%3A%22click_me_123%22%7D%5D%7D%5D) I've cooked with the block kit builder.
![image](https://user-images.githubusercontent.com/43811/80504934-a5f78b80-89ae-11ea-805d-b857aab765f5.png)


~~I've added `style` option to `ConfirmationDialog#confirm` to set value to that field.~~ I've added `ConfirmationDialog#style` method for that field. 

