### PR TITLE
Support description and url fields of Option object

### DIFF
--- a/lib/slack/block_kit/composition/option.rb
+++ b/lib/slack/block_kit/composition/option.rb
@@ -11,12 +11,7 @@ module Slack
         def initialize(value:, text:, emoji: nil, description: nil, url: nil)
           @text = PlainText.new(text: text, emoji: emoji)
           @value = value
-          if description
-            @description = PlainText.new(
-              text: description,
-              emoji: emoji
-            )
-          end
+          @description = PlainText.new(text: description, emoji: emoji) if description
           @url = url
         end
 

--- a/lib/slack/block_kit/composition/option.rb
+++ b/lib/slack/block_kit/composition/option.rb
@@ -8,16 +8,25 @@ module Slack
       # https://api.slack.com/reference/messaging/composition-objects#option
       # https://api.slack.com/reference/messaging/block-elements#select
       class Option
-        def initialize(value:, text:, emoji: nil)
+        def initialize(value:, text:, emoji: nil, description: nil, url: nil)
           @text = PlainText.new(text: text, emoji: emoji)
           @value = value
+          if description
+            @description = PlainText.new(
+              text: description,
+              emoji: emoji
+            )
+          end
+          @url = url
         end
 
         def as_json(*)
           {
             text: @text.as_json,
-            value: @value
-          }
+            value: @value,
+            description: @description&.as_json,
+            url: @url
+          }.compact
         end
       end
     end

--- a/lib/slack/block_kit/element/overflow_menu.rb
+++ b/lib/slack/block_kit/element/overflow_menu.rb
@@ -26,11 +26,12 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(value:, text:, emoji: nil)
+        def option(value:, text:, emoji: nil, url: nil)
           @options << Composition::Option.new(
             value: value,
             text: text,
-            emoji: emoji
+            emoji: emoji,
+            url: url
           )
 
           self

--- a/spec/lib/slack/block_kit/composition/option_spec.rb
+++ b/spec/lib/slack/block_kit/composition/option_spec.rb
@@ -32,5 +32,43 @@ RSpec.describe Slack::BlockKit::Composition::Option do
         expect(instance.as_json).to eq(expected_hash)
       end
     end
+
+    context 'when description is set' do
+      it 'includes description as a plain_text object in the payload' do
+        instance = described_class.new(
+          text: 'some text',
+          value: 'a value',
+          emoji: true,
+          description: 'descriptive text'
+        )
+
+        expected_hash = {
+          value: 'a value',
+          text: { type: 'plain_text', text: 'some text', emoji: true },
+          description: { type: 'plain_text', text: 'descriptive text', emoji: true }
+        }
+
+        expect(instance.as_json).to eq(expected_hash)
+      end
+    end
+
+    context 'when url is set' do
+      it 'includes url in the payload' do
+        instance = described_class.new(
+          text: 'some text',
+          value: 'a value',
+          emoji: true,
+          url: 'https://example.com'
+        )
+
+        expected_hash = {
+          value: 'a value',
+          text: { type: 'plain_text', text: 'some text', emoji: true },
+          url: 'https://example.com'
+        }
+
+        expect(instance.as_json).to eq(expected_hash)
+      end
+    end
   end
 end

--- a/spec/lib/slack/block_kit/element/overflow_menu_spec.rb
+++ b/spec/lib/slack/block_kit/element/overflow_menu_spec.rb
@@ -3,5 +3,41 @@
 require 'spec_helper'
 
 RSpec.describe Slack::BlockKit::Element::OverflowMenu do
-  pending
+  let(:instance) { described_class.new(**params) }
+  let(:action_id) { 'my-action' }
+  let(:params) { { action_id: action_id } }
+
+  describe '#as_json' do
+    subject { instance.as_json }
+
+    let(:expected_json) do
+      {
+        type: 'overflow',
+        action_id: action_id,
+        options: [
+          {
+            'text': {
+              'type': 'plain_text',
+              'text': 'some text'
+            },
+            'value': 'value-0'
+          },
+          {
+            'text': {
+              'type': 'plain_text',
+              'text': 'more text'
+            },
+            'value': 'value-1',
+            'url': 'https://example.com'
+          }
+        ]
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.option(value: 'value-0', text: 'some text')
+      instance.option(value: 'value-1', text: 'more text', url: 'https://example.com')
+      expect(subject).to eq(expected_json)
+    end
+  end
 end


### PR DESCRIPTION
Option object supports description and url fields as per the official API doc (https://api.slack.com/reference/block-kit/composition-objects#option#option). Both are optional fields; `description` is supposed to be used with the radio button, and `url` with the overflow menus. 

### description field

[An example](https://api.slack.com/tools/block-kit-builder?mode=appHome&view=%7B%22type%22%3A%22home%22%2C%22blocks%22%3A%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Check%20out%20these%20rad%20radio%20buttons%22%7D%2C%22accessory%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22action_id%22%3A%22this_is_an_action_id%22%2C%22initial_option%22%3A%7B%22value%22%3A%22A1%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Radio%201%22%7D%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Description%22%7D%7D%2C%22options%22%3A%5B%7B%22value%22%3A%22A1%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Radio%201%22%7D%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Description%22%7D%7D%2C%7B%22value%22%3A%22A2%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Radio%202%22%7D%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Description%22%7D%7D%2C%7B%22value%22%3A%22A3%22%2C%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Radio%202%22%7D%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Description%22%7D%7D%5D%7D%7D%5D%7D)
![image](https://user-images.githubusercontent.com/43811/80509663-ae52c500-89b4-11ea-95d2-aa5e3bea85bb.png)

### url field

[An example](https://api.slack.com/tools/block-kit-builder?mode=message&blocks=%5B%7B%22type%22%3A%22section%22%2C%22block_id%22%3A%22section%20890%22%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22This%20is%20a%20section%20block%20with%20an%20overflow%20menu.%22%7D%2C%22accessory%22%3A%7B%22type%22%3A%22overflow%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22GitHub%22%7D%2C%22value%22%3A%22value-0%22%2C%22url%22%3A%22https%3A%2F%2Fwww.github.com%22%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22*this%20is%20plain_text%20text*%22%7D%2C%22value%22%3A%22value-1%22%7D%5D%2C%22action_id%22%3A%22overflow%22%7D%7D%5D)
![image](https://user-images.githubusercontent.com/43811/80510056-2a4d0d00-89b5-11ea-98d6-ea971287929c.png)
