### PR TITLE
Exclude special files from target of Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,10 @@ Naming/FileName:
 
 Metrics/ParameterLists:
   Max: 8
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+    - '**/*.gemspec'


### PR DESCRIPTION
Exclude files for rake tasks, ones for rspecs, and gemspec file from target of Metrics/BlockLength rubocop rule. This is the same config as what official rubocop repo has: 
https://github.com/rubocop-hq/rubocop/blob/218f476531aa596b89d0227f30530786a8899a82/.rubocop.yml#L84-L89

@CGA1123 Are you happy to add this change? This'll allow https://github.com/CGA1123/slack-ruby-block-kit/pull/14#issuecomment-621477881 to pass rubocop. 