### PR TITLE
Fix ExternalSelect#as_json

### DIFF
--- a/lib/slack/block_kit/element/external_select.rb
+++ b/lib/slack/block_kit/element/external_select.rb
@@ -46,7 +46,7 @@ module Slack
             placeholder: @placeholder.as_json,
             action_id: @action_id,
             initial_option: @initial_option&.as_json,
-            min_query_length: min_query_length,
+            min_query_length: @min_query_length,
             confirm: @confirm&.as_json
           }.compact
         end

--- a/spec/lib/slack/block_kit/element/external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/external_select_spec.rb
@@ -3,5 +3,32 @@
 require 'spec_helper'
 
 RSpec.describe Slack::BlockKit::Element::ExternalSelect do
-  pending
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) {
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  }
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    let(:expected_json) do
+      {
+        type: 'external_select',
+        placeholder: {
+          'type': 'plain_text',
+          'text': placeholder_text
+        },
+        action_id: action_id,
+      }
+    end
+
+    it 'correctly serializes' do
+      expect(as_json).to eq(expected_json)
+    end
+  end
 end

--- a/spec/lib/slack/block_kit/element/external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/external_select_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Slack::BlockKit::Element::ExternalSelect do
   let(:instance) { described_class.new(**params) }
   let(:placeholder_text) { 'some text' }
   let(:action_id) { 'my-action' }
-  let(:params) {
+  let(:params) do
     {
       placeholder: placeholder_text,
       action_id: action_id
     }
-  }
+  end
 
   describe '#as_json' do
     subject(:as_json) { instance.as_json }
@@ -23,7 +23,7 @@ RSpec.describe Slack::BlockKit::Element::ExternalSelect do
           'type': 'plain_text',
           'text': placeholder_text
         },
-        action_id: action_id,
+        action_id: action_id
       }
     end
 


### PR DESCRIPTION
@CGA1123 Hello!

This change fixes a small bug in `Slack::BlockKit::Element::ExternalSelect` --- missing `@` to access an instance var. 