### PR TITLE
Implement multi-select menus

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.5.3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/AsciiComments:

--- a/lib/slack/block_kit/element/multi_channels_select.rb
+++ b/lib/slack/block_kit/element/multi_channels_select.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A select menu, just as with a standard HTML <select> tag, creates a drop
+      # down menu with a list of options for a user to choose. The select menu
+      # also includes type-ahead functionality, where a user can type a part or
+      # all of an option string to filter the list.
+      #
+      # This multi-select menu will populate its options with a list of public
+      # channels visible to the current user in the active workspace.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
+      class MultiChannelsSelect
+        TYPE = 'multi_channels_select'
+
+        attr_accessor :confirm
+
+        def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
+          @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
+          @action_id = action_id
+          @initial_channel = initial
+          @confirm = nil
+          @max_selected_items = max_selected_items
+
+          yield(self) if block_given?
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          self
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            placeholder: @placeholder.as_json,
+            action_id: @action_id,
+            initial_channel: @initial_channel,
+            confirm: @confirm&.as_json,
+            max_selected_items: @max_selected_items
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/element/multi_conversations_select.rb
+++ b/lib/slack/block_kit/element/multi_conversations_select.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A select menu, just as with a standard HTML <select> tag, creates a drop
+      # down menu with a list of options for a user to choose. The select menu
+      # also includes type-ahead functionality, where a user can type a part or
+      # all of an option string to filter the list.
+      #
+      # This multi-select menu will populate its options with a list of public and
+      # private channels, DMs, and MPIMs visible to the current user in the
+      # active workspace.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
+      class MultiConversationsSelect
+        TYPE = 'multi_conversations_select'
+
+        attr_accessor :confirm
+
+        def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
+          @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
+          @action_id = action_id
+          @initial_conversation = initial
+          @confirm = nil
+          @max_selected_items = max_selected_items
+
+          yield(self) if block_given?
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          self
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            placeholder: @placeholder.as_json,
+            action_id: @action_id,
+            initial_conversation: @initial_conversation,
+            confirm: @confirm&.as_json,
+            max_selected_items: @max_selected_items
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/element/multi_external_select.rb
+++ b/lib/slack/block_kit/element/multi_external_select.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A select menu, just as with a standard HTML <select> tag, creates a drop
+      # down menu with a list of options for a user to choose. The select menu
+      # also includes type-ahead functionality, where a user can type a part or
+      # all of an option string to filter the list.
+      #
+      # This select menu will load its options from an external data source,
+      # allowing for a dynamic list of options.
+      #
+      # Each time a select menu of this type is opened or the user starts typing
+      # in the typeahead field, we'll send a request to your specified URL. Your
+      # app should return an HTTP 200 OK response, along with an
+      # application/json post body with an object containing either an options
+      # array, or an option_groups array.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+      class MultiExternalSelect
+        TYPE = 'multi_external_select'
+
+        attr_accessor :confirm
+
+        def initialize(placeholder:, action_id:, initial: nil, min_query_length: nil, emoji: nil, max_selected_items: nil)
+          @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
+          @action_id = action_id
+          @initial_option = initial
+          @min_query_length = min_query_length
+          @confirm = nil
+          @max_selected_items = max_selected_items
+
+          yield(self) if block_given?
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          self
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            placeholder: @placeholder.as_json,
+            action_id: @action_id,
+            initial_option: @initial_option&.as_json,
+            min_query_length: @min_query_length,
+            confirm: @confirm&.as_json,
+            max_selected_items: @max_selected_items
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/element/multi_external_select.rb
+++ b/lib/slack/block_kit/element/multi_external_select.rb
@@ -23,7 +23,9 @@ module Slack
 
         attr_accessor :confirm
 
-        def initialize(placeholder:, action_id:, initial: nil, min_query_length: nil, emoji: nil, max_selected_items: nil)
+        def initialize(placeholder:, action_id:,
+                       initial: nil, min_query_length: nil, emoji: nil, max_selected_items: nil)
+
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
           @initial_option = initial

--- a/lib/slack/block_kit/element/multi_static_select.rb
+++ b/lib/slack/block_kit/element/multi_static_select.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A select menu, just as with a standard HTML <select> tag, creates a drop
+      # down menu with a list of options for a user to choose. The select menu
+      # also includes type-ahead functionality, where a user can type a part or
+      # all of an option string to filter the list.
+      #
+      # This is the simplest form of select menu, with a static list of options
+      # passed in when defining the element.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#static_multi_select
+      class MultiStaticSelect
+        TYPE = 'multi_static_select'
+
+        attr_accessor :confirm, :options, :option_groups, :initial_option
+
+        def initialize(placeholder:, action_id:, emoji: nil, max_selected_items: nil)
+          @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
+          @action_id = action_id
+          @confirm = nil
+          @max_selected_items = max_selected_items
+
+          @options = nil
+          @option_groups = nil
+          @initial_option = nil
+
+          yield(self) if block_given?
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          self
+        end
+
+        def option(value:, text:, emoji: nil)
+          @options ||= []
+          @options << Composition::Option.new(
+            value: value,
+            text: text,
+            emoji: emoji
+          )
+
+          self
+        end
+
+        def option_group(label:, emoji: nil)
+          option_group = Composition::OptionGroup.new(label: label, emoji: emoji)
+
+          yield(option_group) if block_given?
+
+          @option_groups ||= []
+          @option_groups << option_group
+
+          self
+        end
+
+        def initial(value:, text:, emoji: nil)
+          @initial_option = Composition::Option.new(
+            value: value,
+            text: text,
+            emoji: emoji
+          )
+
+          self
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            placeholder: @placeholder.as_json,
+            action_id: @action_id,
+            options: @options&.map(&:as_json),
+            option_groups: @option_groups&.map(&:as_json),
+            initial_option: @initial_option&.as_json,
+            confirm: @confirm&.as_json,
+            max_selected_items: @max_selected_items
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/element/multi_users_select.rb
+++ b/lib/slack/block_kit/element/multi_users_select.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A select menu, just as with a standard HTML <select> tag, creates a drop
+      # down menu with a list of options for a user to choose. The select menu
+      # also includes type-ahead functionality, where a user can type a part or
+      # all of an option string to filter the list.
+      #
+      # This multi-select menu will populate its options with a list of Slack users
+      # visible to the current user in the active workspace.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#users_multi_select
+      class MultiUsersSelect
+        TYPE = 'multi_users_select'
+
+        attr_accessor :confirm
+
+        def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
+          @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
+          @action_id = action_id
+          @initial_user = initial
+          @confirm = nil
+          @max_selected_items = max_selected_items
+
+          yield(self) if block_given?
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          self
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            placeholder: @placeholder.as_json,
+            action_id: @action_id,
+            initial_user: @initial_user,
+            confirm: @confirm&.as_json,
+            max_selected_items: @max_selected_items
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './section/multi_select_elements'
+
 module Slack
   module BlockKit
     module Layout
@@ -8,13 +10,19 @@ module Slack
       # with any of the available block elements.
       #
       # https://api.slack.com/reference/messaging/blocks#section
+      # rubocop:disable Metrics/ClassLength
       class Section
+        # rubocop:enable Metrics/ClassLength
+
+        include Section::MultiSelectElements
         TYPE = 'section'
 
         attr_accessor :fields, :text, :accessory
 
         def initialize(block_id: nil)
           @block_id = block_id
+          @fields = nil
+          @accessory = nil
 
           yield(self) if block_given?
         end

--- a/lib/slack/block_kit/layout/section/multi_select_elements.rb
+++ b/lib/slack/block_kit/layout/section/multi_select_elements.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Layout
+      class Section
+        # Helper methods for Multi Select to inject to section
+        module MultiSelectElements
+          def multi_channels_select(placeholder:, action_id:,
+                                    initial: nil, emoji: nil, max_selected_items: nil)
+            element = Element::MultiChannelsSelect.new(
+              placeholder: placeholder,
+              action_id: action_id,
+              initial: initial,
+              emoji: emoji,
+              max_selected_items: max_selected_items
+            )
+
+            yield(element) if block_given?
+
+            accessorise(element)
+          end
+
+          def multi_conversations_select(placeholder:, action_id:,
+                                         initial: nil, emoji: nil, max_selected_items: nil)
+            element = Element::MultiConversationsSelect.new(
+              placeholder: placeholder,
+              action_id: action_id,
+              initial: initial,
+              emoji: emoji,
+              max_selected_items: max_selected_items
+            )
+
+            yield(element) if block_given?
+
+            accessorise(element)
+          end
+
+          def multi_external_select(placeholder:, action_id:,
+                                    initial: nil,
+                                    min_query_length: nil,
+                                    emoji: nil,
+                                    max_selected_items: nil)
+            element = Element::MultiExternalSelect.new(
+              placeholder: placeholder,
+              action_id: action_id,
+              initial: initial,
+              min_query_length: min_query_length,
+              emoji: emoji,
+              max_selected_items: max_selected_items
+            )
+
+            yield(element) if block_given?
+
+            accessorise(element)
+          end
+
+          def multi_static_select(placeholder:, action_id:,
+                                  emoji: nil, max_selected_items: nil)
+            element = Element::MultiStaticSelect.new(
+              placeholder: placeholder,
+              action_id: action_id,
+              emoji: emoji,
+              max_selected_items: max_selected_items
+            )
+
+            yield(element) if block_given?
+
+            accessorise(element)
+          end
+
+          def multi_users_select(placeholder:, action_id:,
+                                 initial: nil,
+                                 emoji: nil,
+                                 max_selected_items: nil)
+            element = Element::MultiUsersSelect.new(
+              placeholder: placeholder,
+              action_id: action_id,
+              emoji: emoji,
+              initial: initial,
+              max_selected_items: max_selected_items
+            )
+
+            yield(element) if block_given?
+
+            accessorise(element)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) do
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  end
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'multi_channels_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_channels_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'without max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_channels_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
     subject(:as_json) { instance.as_json }
 
     context 'with confirmation dialog' do
+      subject(:as_json) do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+        instance.as_json
+      end
+
       let(:expected_json) do
         {
           type: 'multi_channels_select',
@@ -47,13 +57,6 @@ RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
       end
 
       it 'correctly serializes' do
-        instance.confirmation_dialog do |confirm|
-          confirm.title(text: '__CONFIRM_TITTLE__')
-          confirm.plain_text(text: '__CONFIRM_TEXT__')
-          confirm.confirm(text: '__CONFIRMED__')
-          confirm.deny(text: '__DENIED__')
-        end
-
         expect(as_json).to eq(expected_json)
       end
     end

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) do
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  end
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'without max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
     subject(:as_json) { instance.as_json }
 
     context 'with confirmation dialog' do
+      subject(:as_json) do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+        instance.as_json
+      end
+
       let(:expected_json) do
         {
           type: 'multi_conversations_select',
@@ -47,13 +57,6 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
       end
 
       it 'correctly serializes' do
-        instance.confirmation_dialog do |confirm|
-          confirm.title(text: '__CONFIRM_TITTLE__')
-          confirm.plain_text(text: '__CONFIRM_TEXT__')
-          confirm.confirm(text: '__CONFIRMED__')
-          confirm.deny(text: '__DENIED__')
-        end
-
         expect(as_json).to eq(expected_json)
       end
     end

--- a/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Slack::BlockKit::Element::MultiExternalSelect do
     subject(:as_json) { instance.as_json }
 
     context 'with confirmation dialog' do
+      subject(:as_json) do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+        instance.as_json
+      end
+
       let(:expected_json) do
         {
           type: 'multi_external_select',
@@ -47,13 +57,6 @@ RSpec.describe Slack::BlockKit::Element::MultiExternalSelect do
       end
 
       it 'correctly serializes' do
-        instance.confirmation_dialog do |confirm|
-          confirm.title(text: '__CONFIRM_TITTLE__')
-          confirm.plain_text(text: '__CONFIRM_TEXT__')
-          confirm.confirm(text: '__CONFIRMED__')
-          confirm.deny(text: '__DENIED__')
-        end
-
         expect(as_json).to eq(expected_json)
       end
     end

--- a/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::MultiExternalSelect do
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) do
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  end
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'multi_external_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_external_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'without max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_external_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
   describe '#as_json' do
     subject(:as_json) { instance.as_json }
 
+    let(:expected_json) do
+      {
+        type: 'multi_static_select',
+        placeholder: {
+          'type': 'plain_text',
+          'text': placeholder_text
+        },
+        action_id: action_id
+      }
+    end
+
     context 'with confirmation dialog' do
       let(:expected_json) do
         {
@@ -92,22 +103,137 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
         }
       end
 
-      let(:expected_json) do
-        {
-          type: 'multi_static_select',
-          placeholder: {
-            'type': 'plain_text',
-            'text': placeholder_text
-          },
-          action_id: action_id
-        }
-      end
-
       it 'correctly serializes' do
         expect(as_json).to eq(expected_json)
       end
     end
 
-    # TODO: Add more test for options/options group
+    context 'with options' do
+      let(:expected_options) do
+        [
+          {
+            text: {
+              text: '__TEXT_1__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_1__'
+          },
+          {
+            text: {
+              text: '__TEXT_2__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_2__'
+          },
+          {
+            text: {
+              text: '__TEXT_3__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_3__'
+          }
+        ]
+      end
+
+      it 'correctly serializes' do
+        instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
+        instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+
+        expect(as_json).to eq(expected_json.merge(options: expected_options))
+      end
+
+      context 'with initial option' do
+        let(:expected_initial) do
+          {
+            text: {
+              text: '__TEXT_2__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_2__'
+          }
+        end
+
+        it 'correctly serializes' do
+          instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
+          instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
+          instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+
+          instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
+
+          expect(as_json).to eq(expected_json.merge(options: expected_options, initial_option: expected_initial))
+        end
+      end
+    end
+
+    context 'with option_groups' do
+      let(:expected_option_groups) do
+        [
+          {
+            label: {
+              text: '__GROUP__',
+              type: 'plain_text'
+            },
+            options: [
+              {
+                text: {
+                  text: '__TEXT_1__',
+                  type: 'plain_text'
+                },
+                value: '__VALUE_1__'
+              },
+              {
+                text: {
+                  text: '__TEXT_2__',
+                  type: 'plain_text'
+                },
+                value: '__VALUE_2__'
+              },
+              {
+                text: {
+                  text: '__TEXT_3__',
+                  type: 'plain_text'
+                },
+                value: '__VALUE_3__'
+              }
+            ]
+          }
+        ]
+      end
+
+      it 'correctly serializes' do
+        instance.option_group(label: '__GROUP__') do |group|
+          group.option(value: '__VALUE_1__', text: '__TEXT_1__')
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__')
+          group.option(value: '__VALUE_3__', text: '__TEXT_3__')
+        end
+
+        expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups))
+      end
+
+      context 'with initial option' do
+        let(:expected_initial) do
+          {
+            text: {
+              text: '__TEXT_2__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_2__'
+          }
+        end
+
+        it 'correctly serializes' do
+          instance.option_group(label: '__GROUP__') do |group|
+            group.option(value: '__VALUE_1__', text: '__TEXT_1__')
+            group.option(value: '__VALUE_2__', text: '__TEXT_2__')
+            group.option(value: '__VALUE_3__', text: '__TEXT_3__')
+          end
+
+          instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
+
+          expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups, initial_option: expected_initial))
+        end
+      end
+    end
   end
 end

--- a/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
@@ -13,6 +13,76 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     }
   end
 
+  let(:expected_option_groups) do
+    [
+      {
+        label: {
+          text: '__GROUP__',
+          type: 'plain_text'
+        },
+        options: [
+          {
+            text: {
+              text: '__TEXT_1__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_1__'
+          },
+          {
+            text: {
+              text: '__TEXT_2__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_2__'
+          },
+          {
+            text: {
+              text: '__TEXT_3__',
+              type: 'plain_text'
+            },
+            value: '__VALUE_3__'
+          }
+        ]
+      }
+    ]
+  end
+
+  let(:expected_initial) do
+    {
+      text: {
+        text: '__TEXT_2__',
+        type: 'plain_text'
+      },
+      value: '__VALUE_2__'
+    }
+  end
+
+  let(:expected_options) do
+    [
+      {
+        text: {
+          text: '__TEXT_1__',
+          type: 'plain_text'
+        },
+        value: '__VALUE_1__'
+      },
+      {
+        text: {
+          text: '__TEXT_2__',
+          type: 'plain_text'
+        },
+        value: '__VALUE_2__'
+      },
+      {
+        text: {
+          text: '__TEXT_3__',
+          type: 'plain_text'
+        },
+        value: '__VALUE_3__'
+      }
+    ]
+  end
+
   describe '#as_json' do
     subject(:as_json) { instance.as_json }
 
@@ -28,6 +98,16 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     end
 
     context 'with confirmation dialog' do
+      subject(:as_json) do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+        instance.as_json
+      end
+
       let(:expected_json) do
         {
           type: 'multi_static_select',
@@ -58,13 +138,6 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
       end
 
       it 'correctly serializes' do
-        instance.confirmation_dialog do |confirm|
-          confirm.title(text: '__CONFIRM_TITTLE__')
-          confirm.plain_text(text: '__CONFIRM_TEXT__')
-          confirm.confirm(text: '__CONFIRMED__')
-          confirm.deny(text: '__DENIED__')
-        end
-
         expect(as_json).to eq(expected_json)
       end
     end
@@ -109,130 +182,62 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     end
 
     context 'with options' do
-      let(:expected_options) do
-        [
-          {
-            text: {
-              text: '__TEXT_1__',
-              type: 'plain_text'
-            },
-            value: '__VALUE_1__'
-          },
-          {
-            text: {
-              text: '__TEXT_2__',
-              type: 'plain_text'
-            },
-            value: '__VALUE_2__'
-          },
-          {
-            text: {
-              text: '__TEXT_3__',
-              type: 'plain_text'
-            },
-            value: '__VALUE_3__'
-          }
-        ]
-      end
-
-      it 'correctly serializes' do
+      subject(:as_json) do
         instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
         instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
         instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
-
-        expect(as_json).to eq(expected_json.merge(options: expected_options))
+        instance.as_json
       end
 
-      context 'with initial option' do
-        let(:expected_initial) do
-          {
-            text: {
-              text: '__TEXT_2__',
-              type: 'plain_text'
-            },
-            value: '__VALUE_2__'
-          }
-        end
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json.merge(options: expected_options))
+      end
+    end
 
-        it 'correctly serializes' do
-          instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
-          instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
-          instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+    context 'with options and initial option' do
+      subject(:as_json) do
+        instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
+        instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+        instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
+        instance.as_json
+      end
 
-          instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
-
-          expect(as_json).to eq(expected_json.merge(options: expected_options, initial_option: expected_initial))
-        end
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json.merge(options: expected_options,
+                                                  initial_option: expected_initial))
       end
     end
 
     context 'with option_groups' do
-      let(:expected_option_groups) do
-        [
-          {
-            label: {
-              text: '__GROUP__',
-              type: 'plain_text'
-            },
-            options: [
-              {
-                text: {
-                  text: '__TEXT_1__',
-                  type: 'plain_text'
-                },
-                value: '__VALUE_1__'
-              },
-              {
-                text: {
-                  text: '__TEXT_2__',
-                  type: 'plain_text'
-                },
-                value: '__VALUE_2__'
-              },
-              {
-                text: {
-                  text: '__TEXT_3__',
-                  type: 'plain_text'
-                },
-                value: '__VALUE_3__'
-              }
-            ]
-          }
-        ]
-      end
-
-      it 'correctly serializes' do
+      subject(:as_json) do
         instance.option_group(label: '__GROUP__') do |group|
           group.option(value: '__VALUE_1__', text: '__TEXT_1__')
           group.option(value: '__VALUE_2__', text: '__TEXT_2__')
           group.option(value: '__VALUE_3__', text: '__TEXT_3__')
         end
-
-        expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups))
+        instance.as_json
       end
 
-      context 'with initial option' do
-        let(:expected_initial) do
-          {
-            text: {
-              text: '__TEXT_2__',
-              type: 'plain_text'
-            },
-            value: '__VALUE_2__'
-          }
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups))
+      end
+    end
+
+    context 'with option_groups and initial option' do
+      subject(:as_json) do
+        instance.option_group(label: '__GROUP__') do |group|
+          group.option(value: '__VALUE_1__', text: '__TEXT_1__')
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__')
+          group.option(value: '__VALUE_3__', text: '__TEXT_3__')
         end
+        instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
+        instance.as_json
+      end
 
-        it 'correctly serializes' do
-          instance.option_group(label: '__GROUP__') do |group|
-            group.option(value: '__VALUE_1__', text: '__TEXT_1__')
-            group.option(value: '__VALUE_2__', text: '__TEXT_2__')
-            group.option(value: '__VALUE_3__', text: '__TEXT_3__')
-          end
-
-          instance.initial(value: '__VALUE_2__', text: '__TEXT_2__')
-
-          expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups, initial_option: expected_initial))
-        end
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups,
+                                                  initial_option: expected_initial))
       end
     end
   end

--- a/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) do
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  end
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'multi_static_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_static_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'without max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_static_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    # TODO: Add more test for options/options group
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
+  let(:instance) { described_class.new(**params) }
+  let(:placeholder_text) { 'some text' }
+  let(:action_id) { 'my-action' }
+  let(:params) do
+    {
+      placeholder: placeholder_text,
+      action_id: action_id
+    }
+  end
+
+  describe '#as_json' do
+    subject(:as_json) { instance.as_json }
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'multi_users_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_users_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          max_selected_items: 10
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'without max_selected_items' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_users_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
     subject(:as_json) { instance.as_json }
 
     context 'with confirmation dialog' do
+      subject(:as_json) do
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+        instance.as_json
+      end
+
       let(:expected_json) do
         {
           type: 'multi_users_select',
@@ -47,13 +57,6 @@ RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
       end
 
       it 'correctly serializes' do
-        instance.confirmation_dialog do |confirm|
-          confirm.title(text: '__CONFIRM_TITTLE__')
-          confirm.plain_text(text: '__CONFIRM_TEXT__')
-          confirm.confirm(text: '__CONFIRMED__')
-          confirm.deny(text: '__DENIED__')
-        end
-
         expect(as_json).to eq(expected_json)
       end
     end

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -3,5 +3,120 @@
 require 'spec_helper'
 
 RSpec.describe Slack::BlockKit::Layout::Section do
-  pending
+  subject(:section_json) { instance.as_json }
+
+  let(:instance) do
+    block = described_class.new(block_id: '__BLOCK__')
+    block.plain_text(text: '__BLOCK_TEXT__')
+    block
+  end
+  let(:expected_json) do
+    {
+      block_id: '__BLOCK__',
+      text: {
+        text: '__BLOCK_TEXT__',
+        type: 'plain_text'
+      },
+      type: 'section'
+    }
+  end
+
+  it 'correctly serializes' do
+    expect(section_json).to eq(expected_json)
+  end
+
+  describe '#multi_channels_select' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'multi_channels_select'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.multi_channels_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
+  describe '#multi_conversations_select' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'multi_conversations_select'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.multi_conversations_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
+  describe '#multi_external_select' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'multi_external_select'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.multi_external_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
+  describe '#multi_static_select' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'multi_static_select'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.multi_static_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
+  describe '#multi_users_select' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'multi_users_select'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.multi_users_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
 end


### PR DESCRIPTION
Implement https://github.com/CGA1123/slack-ruby-block-kit/issues/18

* Basically, they're the same single choice versions, with an optional option `max_selected_items`. 
* Unit test is just enough for statement coverage. 
* I prefer clone than inherit because we rely on Slack API, nothing guarantees that multi-choice versions rely on single-choice versions. But if it happened in the future, I think we could easily refactor back to inherit way. 