### PR TITLE
Implement conversations filter

### DIFF
--- a/lib/slack/block_kit/composition/conversation_filter.rb
+++ b/lib/slack/block_kit/composition/conversation_filter.rb
@@ -3,7 +3,7 @@
 module Slack
   module BlockKit
     module Composition
-      # Provides a way to filter the list of optionsin a conversations select menu
+      # Provides a way to filter the list of options in a conversations select menu
       # or conversations multi-select menu.
       #
       # @param [Array] conversation_types - "include" field

--- a/lib/slack/block_kit/composition/conversation_filter.rb
+++ b/lib/slack/block_kit/composition/conversation_filter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Composition
+      # Provides a way to filter the list of optionsin a conversations select menu
+      # or conversations multi-select menu.
+      #
+      # @param [Array] conversation_types - "include" field
+      #
+      # https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
+      # https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
+      # https://api.slack.com/reference/block-kit/block-elements#conversation_select
+      class ConversationFilter
+        def initialize(conversation_types: nil,
+                       exclude_external_shared_channels: nil,
+                       exclude_bot_users: nil)
+          @conversation_types = conversation_types
+          @exclude_external_shared_channels = exclude_external_shared_channels
+          @exclude_bot_users = exclude_bot_users
+        end
+
+        def as_json(*)
+          {
+            include: @conversation_types,
+            exclude_external_shared_channels: @exclude_external_shared_channels,
+            exclude_bot_users: @exclude_bot_users
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/composition/conversation_filter.rb
+++ b/lib/slack/block_kit/composition/conversation_filter.rb
@@ -6,23 +6,23 @@ module Slack
       # Provides a way to filter the list of options in a conversations select menu
       # or conversations multi-select menu.
       #
-      # @param [Array] conversation_types - "include" field
+      # @param [Array] only - "include" field
       #
       # https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
       # https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
       # https://api.slack.com/reference/block-kit/block-elements#conversation_select
       class ConversationFilter
-        def initialize(conversation_types: nil,
+        def initialize(only: nil,
                        exclude_external_shared_channels: nil,
                        exclude_bot_users: nil)
-          @conversation_types = conversation_types
+          @only = only
           @exclude_external_shared_channels = exclude_external_shared_channels
           @exclude_bot_users = exclude_bot_users
         end
 
         def as_json(*)
           {
-            include: @conversation_types,
+            include: @only,
             exclude_external_shared_channels: @exclude_external_shared_channels,
             exclude_bot_users: @exclude_bot_users
           }.compact

--- a/lib/slack/block_kit/element/conversations_select.rb
+++ b/lib/slack/block_kit/element/conversations_select.rb
@@ -35,11 +35,11 @@ module Slack
           self
         end
 
-        def filter(conversation_types: nil,
+        def filter(only: nil,
                    exclude_external_shared_channels: nil,
                    exclude_bot_users: nil)
           @filter = Composition::ConversationFilter.new(
-            conversation_types: conversation_types,
+            only: only,
             exclude_external_shared_channels: exclude_external_shared_channels,
             exclude_bot_users: exclude_bot_users
           )

--- a/lib/slack/block_kit/element/conversations_select.rb
+++ b/lib/slack/block_kit/element/conversations_select.rb
@@ -22,6 +22,7 @@ module Slack
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
           @initial_conversation = initial
+          @filter = nil
 
           yield(self) if block_given?
         end
@@ -34,13 +35,26 @@ module Slack
           self
         end
 
+        def filter(conversation_types: nil,
+                   exclude_external_shared_channels: nil,
+                   exclude_bot_users: nil)
+          @filter = Composition::ConversationFilter.new(
+            conversation_types: conversation_types,
+            exclude_external_shared_channels: exclude_external_shared_channels,
+            exclude_bot_users: exclude_bot_users
+          )
+
+          self
+        end
+
         def as_json(*)
           {
             type: TYPE,
             placeholder: @placeholder.as_json,
             action_id: @action_id,
             initial_conversation: @initial_conversation,
-            confirm: @confirm&.as_json
+            confirm: @confirm&.as_json,
+            filter: @filter&.as_json
           }.compact
         end
       end

--- a/lib/slack/block_kit/element/multi_conversations_select.rb
+++ b/lib/slack/block_kit/element/multi_conversations_select.rb
@@ -24,6 +24,7 @@ module Slack
           @initial_conversation = initial
           @confirm = nil
           @max_selected_items = max_selected_items
+          @filter = nil
 
           yield(self) if block_given?
         end
@@ -36,6 +37,18 @@ module Slack
           self
         end
 
+        def filter(conversation_types: nil,
+                   exclude_external_shared_channels: nil,
+                   exclude_bot_users: nil)
+          @filter = Composition::ConversationFilter.new(
+            conversation_types: conversation_types,
+            exclude_external_shared_channels: exclude_external_shared_channels,
+            exclude_bot_users: exclude_bot_users
+          )
+
+          self
+        end
+
         def as_json(*)
           {
             type: TYPE,
@@ -43,7 +56,8 @@ module Slack
             action_id: @action_id,
             initial_conversation: @initial_conversation,
             confirm: @confirm&.as_json,
-            max_selected_items: @max_selected_items
+            max_selected_items: @max_selected_items,
+            filter: @filter&.as_json
           }.compact
         end
       end

--- a/lib/slack/block_kit/element/multi_conversations_select.rb
+++ b/lib/slack/block_kit/element/multi_conversations_select.rb
@@ -37,11 +37,11 @@ module Slack
           self
         end
 
-        def filter(conversation_types: nil,
+        def filter(only: nil,
                    exclude_external_shared_channels: nil,
                    exclude_bot_users: nil)
           @filter = Composition::ConversationFilter.new(
-            conversation_types: conversation_types,
+            only: only,
             exclude_external_shared_channels: exclude_external_shared_channels,
             exclude_bot_users: exclude_bot_users
           )

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -111,4 +111,135 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
       end
     end
   end
+
+  describe '#filter' do
+    context 'when filter by conversation type' do
+      subject(:as_json) do
+        instance.filter(conversation_types: ['im'])
+        instance.as_json
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          filter: {
+            include: ['im']
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'when filter by multiple conversation type' do
+      subject(:as_json) do
+        instance.filter(conversation_types: %w[im public])
+        instance.as_json
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          filter: {
+            include: %w[im public]
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'when filter external_shared_channels' do
+      subject(:as_json) do
+        instance.filter(exclude_external_shared_channels: true)
+        instance.as_json
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          filter: {
+            exclude_external_shared_channels: true
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'when filter bot_users' do
+      subject(:as_json) do
+        instance.filter(exclude_bot_users: true)
+        instance.as_json
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          filter: {
+            exclude_bot_users: true
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'when filter all options' do
+      subject(:as_json) do
+        instance.filter(exclude_bot_users: true,
+                        exclude_external_shared_channels: true,
+                        conversation_types: ['im'])
+        instance.as_json
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          filter: {
+            include: ['im'],
+            exclude_external_shared_channels: true,
+            exclude_bot_users: true
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
 end

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
   describe '#filter' do
     context 'when filter by conversation type' do
       subject(:as_json) do
-        instance.filter(conversation_types: ['im'])
+        instance.filter(only: ['im'])
         instance.as_json
       end
 
@@ -140,7 +140,7 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
 
     context 'when filter by multiple conversation type' do
       subject(:as_json) do
-        instance.filter(conversation_types: %w[im public])
+        instance.filter(only: %w[im public])
         instance.as_json
       end
 
@@ -217,7 +217,7 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
       subject(:as_json) do
         instance.filter(exclude_bot_users: true,
                         exclude_external_shared_channels: true,
-                        conversation_types: ['im'])
+                        only: ['im'])
         instance.as_json
       end
 


### PR DESCRIPTION
Implement https://github.com/CGA1123/slack-ruby-block-kit/issues/17

The only concern is `filter`'s `include` attribute is replaced by `conversation_types` because `include` is a keyword. 