### PR TITLE
Fix image accessorise method call in sections

### DIFF
--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -157,7 +157,7 @@ module Slack
         end
 
         def image(url:, alt_text:)
-          accessorize(Element::Image.new(image_url: url, alt_text: alt_text))
+          accessorise(Element::Image.new(image_url: url, alt_text: alt_text))
         end
 
         def accessorise(element)


### PR DESCRIPTION
Noticed this the other day -- I think you just had a little typo with this method.