### PR TITLE
Implement `Slack::BlockKit::Element::Checkboxes`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,6 +30,7 @@ RSpec/ExampleLength:
     - 'spec/lib/slack/block_kit/composition/confirmation_dialog_spec.rb'
     - 'spec/lib/slack/block_kit/composition/option_group_spec.rb'
     - 'spec/lib/slack/block_kit/composition/option_spec.rb'
+    - 'spec/lib/slack/block_kit/element/checkboxes_spec.rb'
 
 # Offense count: 4
 Style/Documentation:

--- a/lib/slack/block_kit/element/checkboxes.rb
+++ b/lib/slack/block_kit/element/checkboxes.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # A checkbox group that allows a user to choose multiple items from
+      # a list of possible options.
+      #
+      # https://api.slack.com/reference/messaging/block-elements#checkboxes
+      class Checkboxes
+        TYPE = 'checkboxes'
+
+        attr_accessor :confirm
+
+        def initialize(action_id:)
+          @action_id = action_id
+          @options = []
+          @initial_options = []
+          @confirm = nil
+
+          yield(self) if block_given?
+        end
+
+        def option(value:, text:, description: nil)
+          @options << Composition::Option.new(
+            value: value,
+            text: text,
+            description: description
+          )
+
+          self
+        end
+
+        def initial(value:, text:, description: nil)
+          @initial_options << Composition::Option.new(
+            value: value,
+            text: text,
+            description: description
+          )
+
+          self
+        end
+
+        def confirmation_dialog
+          @confirm = Composition::ConfirmationDialog.new
+
+          yield(@confirm) if block_given?
+
+          @confirm
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            action_id: @action_id,
+            options: @options.map(&:as_json),
+            initial_options: @initial_options.any? ? @initial_options.map(&:as_json) : nil,
+            confirm: @confirm&.as_json
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -156,6 +156,16 @@ module Slack
           accessorise(element)
         end
 
+        def checkboxes(action_id:)
+          element = Element::Checkboxes.new(
+            action_id: action_id
+          )
+
+          yield(element) if block_given?
+
+          accessorise(element)
+        end
+
         def image(url:, alt_text:)
           accessorise(Element::Image.new(image_url: url, alt_text: alt_text))
         end

--- a/spec/lib/slack/block_kit/element/checkboxes_spec.rb
+++ b/spec/lib/slack/block_kit/element/checkboxes_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::Checkboxes do
+  subject(:as_json) { instance.as_json }
+
+  let(:instance) { described_class.new(**params) }
+  let(:action_id) { 'my-action' }
+  let(:params) { { action_id: action_id } }
+  let(:option) { { value: 'option-1', text: 'Option 1' } }
+  let(:option_description) { { value: 'option-2', text: 'Option 2', description: 'description' } }
+  let(:another_option) { { value: 'option-3', text: 'Option 3' } }
+
+  describe '#as_json' do
+    let(:expected_json) do
+      {
+        type: 'checkboxes',
+        action_id: action_id,
+        options: [
+          {
+            text: {
+              type: 'plain_text',
+              text: 'Option 1'
+            },
+            value: 'option-1'
+          },
+          {
+            text: {
+              type: 'plain_text',
+              text: 'Option 2'
+            },
+            description: {
+              type: 'plain_text',
+              text: 'description'
+            },
+            value: 'option-2'
+          }
+        ]
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.option(option)
+      instance.option(option_description)
+
+      expect(as_json).to eq(expected_json)
+    end
+
+    context 'with initial options' do
+      let(:expected_json) do
+        {
+          type: 'checkboxes',
+          action_id: action_id,
+          options: [
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 1'
+              },
+              value: 'option-1'
+            },
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 2'
+              },
+              description: {
+                type: 'plain_text',
+                text: 'description'
+              },
+              value: 'option-2'
+            },
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 3'
+              },
+              value: 'option-3'
+            }
+          ],
+          initial_options: [
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 1'
+              },
+              value: 'option-1'
+            },
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 2'
+              },
+              description: {
+                type: 'plain_text',
+                text: 'description'
+              },
+              value: 'option-2'
+            }
+          ]
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.option(option)
+        instance.option(option_description)
+        instance.option(another_option)
+
+        instance.initial(option)
+        instance.initial(option_description)
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
+    context 'with confirmation dialog' do
+      let(:expected_json) do
+        {
+          type: 'checkboxes',
+          action_id: action_id,
+          options: [
+            {
+              text: {
+                type: 'plain_text',
+                text: 'Option 1'
+              },
+              value: 'option-1'
+            }
+          ],
+          confirm: {
+            confirm: {
+              text: '__CONFIRMED__',
+              type: 'plain_text'
+            },
+            deny: {
+              text: '__DENIED__',
+              type: 'plain_text'
+            },
+            text: {
+              text: '__CONFIRM_TEXT__',
+              type: 'plain_text'
+            },
+            title: {
+              text: '__CONFIRM_TITTLE__',
+              type: 'plain_text'
+            }
+          }
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.option(option)
+        instance.confirmation_dialog do |confirm|
+          confirm.title(text: '__CONFIRM_TITTLE__')
+          confirm.plain_text(text: '__CONFIRM_TEXT__')
+          confirm.confirm(text: '__CONFIRMED__')
+          confirm.deny(text: '__DENIED__')
+        end
+
+        expect(as_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -120,6 +120,32 @@ RSpec.describe Slack::BlockKit::Layout::Section do
     end
   end
 
+  describe '#checkboxes' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        options: [
+          {
+            value: '__VALUE__',
+            text: {
+              type: 'plain_text',
+              text: '__TEXT__'
+            }
+          }
+        ],
+        type: 'checkboxes'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.checkboxes(action_id: '__ACTION_ID__') do |checkboxes|
+        checkboxes.option(value: '__VALUE__', text: '__TEXT__')
+      end
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
   describe '#image' do
     let(:expected_accessory_json) do
       {


### PR DESCRIPTION
Implement #10 `Slack::BlockKit::Element::CheckboxGroup` based on https://api.slack.com/reference/block-kit/block-elements#checkboxes

It supports all the fields `action_id`, `type`, `options`, `initial_options` and `confirmation`.