### PR TITLE
Fix JSON attributes on element with initial values

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,6 +17,12 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 117
 
+# Offense count: 1
+# Configuration parameters: IgnoredMethods.
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'lib/slack/block_kit/element/multi_static_select.rb'
+
 # Offense count: 5
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/lib/slack/block_kit/element/multi_channels_select.rb
+++ b/lib/slack/block_kit/element/multi_channels_select.rb
@@ -20,7 +20,7 @@ module Slack
         def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
-          @initial_channel = initial
+          @initial_channels = initial
           @confirm = nil
           @max_selected_items = max_selected_items
 
@@ -40,7 +40,7 @@ module Slack
             type: TYPE,
             placeholder: @placeholder.as_json,
             action_id: @action_id,
-            initial_channel: @initial_channel,
+            initial_channels: @initial_channels,
             confirm: @confirm&.as_json,
             max_selected_items: @max_selected_items
           }.compact

--- a/lib/slack/block_kit/element/multi_conversations_select.rb
+++ b/lib/slack/block_kit/element/multi_conversations_select.rb
@@ -21,7 +21,7 @@ module Slack
         def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
-          @initial_conversation = initial
+          @initial_conversations = initial
           @confirm = nil
           @max_selected_items = max_selected_items
           @filter = nil
@@ -54,7 +54,7 @@ module Slack
             type: TYPE,
             placeholder: @placeholder.as_json,
             action_id: @action_id,
-            initial_conversation: @initial_conversation,
+            initial_conversations: @initial_conversations,
             confirm: @confirm&.as_json,
             max_selected_items: @max_selected_items,
             filter: @filter&.as_json

--- a/lib/slack/block_kit/element/multi_external_select.rb
+++ b/lib/slack/block_kit/element/multi_external_select.rb
@@ -28,7 +28,7 @@ module Slack
 
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
-          @initial_option = initial
+          @initial_options = initial
           @min_query_length = min_query_length
           @confirm = nil
           @max_selected_items = max_selected_items
@@ -49,7 +49,7 @@ module Slack
             type: TYPE,
             placeholder: @placeholder.as_json,
             action_id: @action_id,
-            initial_option: @initial_option&.as_json,
+            initial_options: @initial_options&.map(&:as_json),
             min_query_length: @min_query_length,
             confirm: @confirm&.as_json,
             max_selected_items: @max_selected_items

--- a/lib/slack/block_kit/element/multi_static_select.rb
+++ b/lib/slack/block_kit/element/multi_static_select.rb
@@ -15,7 +15,7 @@ module Slack
       class MultiStaticSelect
         TYPE = 'multi_static_select'
 
-        attr_accessor :confirm, :options, :option_groups, :initial_option
+        attr_accessor :confirm, :options, :option_groups, :initial_options
 
         def initialize(placeholder:, action_id:, emoji: nil, max_selected_items: nil)
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
@@ -25,7 +25,7 @@ module Slack
 
           @options = nil
           @option_groups = nil
-          @initial_option = nil
+          @initial_options = nil
 
           yield(self) if block_given?
         end
@@ -61,7 +61,8 @@ module Slack
         end
 
         def initial(value:, text:, emoji: nil)
-          @initial_option = Composition::Option.new(
+          @initial_options ||= []
+          @initial_options << Composition::Option.new(
             value: value,
             text: text,
             emoji: emoji
@@ -77,7 +78,7 @@ module Slack
             action_id: @action_id,
             options: @options&.map(&:as_json),
             option_groups: @option_groups&.map(&:as_json),
-            initial_option: @initial_option&.as_json,
+            initial_options: @initial_options&.map(&:as_json),
             confirm: @confirm&.as_json,
             max_selected_items: @max_selected_items
           }.compact

--- a/lib/slack/block_kit/element/multi_users_select.rb
+++ b/lib/slack/block_kit/element/multi_users_select.rb
@@ -20,7 +20,7 @@ module Slack
         def initialize(placeholder:, action_id:, initial: nil, emoji: nil, max_selected_items: nil)
           @placeholder = Composition::PlainText.new(text: placeholder, emoji: emoji)
           @action_id = action_id
-          @initial_user = initial
+          @initial_users = initial
           @confirm = nil
           @max_selected_items = max_selected_items
 
@@ -40,7 +40,7 @@ module Slack
             type: TYPE,
             placeholder: @placeholder.as_json,
             action_id: @action_id,
-            initial_user: @initial_user,
+            initial_users: @initial_users,
             confirm: @confirm&.as_json,
             max_selected_items: @max_selected_items
           }.compact

--- a/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
         {
           placeholder: placeholder_text,
           action_id: action_id,
-          initial: ['channel-1', 'channel-2']
+          initial: %w[channel-1 channel-2]
         }
       end
       let(:expected_json) do
@@ -77,7 +77,7 @@ RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
             'text': placeholder_text
           },
           action_id: action_id,
-          initial_channels: ['channel-1', 'channel-2']
+          initial_channels: %w[channel-1 channel-2]
         }
       end
 

--- a/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_channels_select_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe Slack::BlockKit::Element::MultiChannelsSelect do
       end
     end
 
+    context 'with initial_channels' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          initial: ['channel-1', 'channel-2']
+        }
+      end
+      let(:expected_json) do
+        {
+          type: 'multi_channels_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          initial_channels: ['channel-1', 'channel-2']
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
     context 'with max_selected_items' do
       let(:params) do
         {

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -61,6 +61,32 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
       end
     end
 
+    context 'with initial_conversations' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          initial: ['conv1', 'conv2']
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_conversations_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          initial_conversations: ['conv1', 'conv2']
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
     context 'with max_selected_items' do
       let(:params) do
         {

--- a/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_conversations_select_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
         {
           placeholder: placeholder_text,
           action_id: action_id,
-          initial: ['conv1', 'conv2']
+          initial: %w[conv1 conv2]
         }
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Slack::BlockKit::Element::MultiConversationsSelect do
             'text': placeholder_text
           },
           action_id: action_id,
-          initial_conversations: ['conv1', 'conv2']
+          initial_conversations: %w[conv1 conv2]
         }
       end
 

--- a/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
@@ -61,6 +61,41 @@ RSpec.describe Slack::BlockKit::Element::MultiExternalSelect do
       end
     end
 
+    context 'with initial_options' do
+      let(:initial_option) { Slack::BlockKit::Composition::Option.new(value: 'value-0', text: '*this is plain_text text*') }
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          initial: [initial_option]
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'multi_external_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          initial_options: [
+            {
+              text: {
+                type: 'plain_text',
+                text: '*this is plain_text text*'
+              },
+              value: 'value-0'
+            }
+          ]
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
     context 'with max_selected_items' do
       let(:params) do
         {

--- a/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_external_select_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe Slack::BlockKit::Element::MultiExternalSelect do
     end
 
     context 'with initial_options' do
-      let(:initial_option) { Slack::BlockKit::Composition::Option.new(value: 'value-0', text: '*this is plain_text text*') }
+      let(:initial_option) do
+        Slack::BlockKit::Composition::Option.new(value: 'value-0', text: '*this is plain_text text*')
+      end
       let(:params) do
         {
           placeholder: placeholder_text,

--- a/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
@@ -47,14 +47,16 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     ]
   end
 
-  let(:expected_initial) do
-    {
-      text: {
-        text: '__TEXT_2__',
-        type: 'plain_text'
-      },
-      value: '__VALUE_2__'
-    }
+  let(:expected_initial_options) do
+    [
+      {
+        text: {
+          text: '__TEXT_2__',
+          type: 'plain_text'
+        },
+        value: '__VALUE_2__'
+      }
+    ]
   end
 
   let(:expected_options) do
@@ -205,7 +207,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
       it 'correctly serializes' do
         expect(as_json).to eq(expected_json.merge(options: expected_options,
-                                                  initial_option: expected_initial))
+                                                  initial_options: expected_initial_options))
       end
     end
 
@@ -237,7 +239,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
       it 'correctly serializes' do
         expect(as_json).to eq(expected_json.merge(option_groups: expected_option_groups,
-                                                  initial_option: expected_initial))
+                                                  initial_options: expected_initial_options))
       end
     end
   end

--- a/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
         {
           placeholder: placeholder_text,
           action_id: action_id,
-          initial: ['user1', 'user2']
+          initial: %w[user1 user2]
         }
       end
       let(:expected_json) do
@@ -77,7 +77,7 @@ RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
             'text': placeholder_text
           },
           action_id: action_id,
-          initial_users: ['user1', 'user2']
+          initial_users: %w[user1 user2]
         }
       end
 

--- a/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_users_select_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe Slack::BlockKit::Element::MultiUsersSelect do
       end
     end
 
+    context 'with initial users' do
+      let(:params) do
+        {
+          placeholder: placeholder_text,
+          action_id: action_id,
+          initial: ['user1', 'user2']
+        }
+      end
+      let(:expected_json) do
+        {
+          type: 'multi_users_select',
+          placeholder: {
+            'type': 'plain_text',
+            'text': placeholder_text
+          },
+          action_id: action_id,
+          initial_users: ['user1', 'user2']
+        }
+      end
+
+      it 'correctly serializes' do
+        expect(as_json).to eq(expected_json)
+      end
+    end
+
     context 'with max_selected_items' do
       let(:params) do
         {


### PR DESCRIPTION
This PR changes `initial_*` JSON attributes to plural:
- `multi_external_select`
- `multi_static_select`
- `multi_conversations_select`
- `multi_channels_select`
- `multi_users_select`

Fixes #45 

