### PR TITLE
Update how initial options are set

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,3 +68,6 @@ Style/RedundantRegexpEscape:
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10
+
+RSpec/NestedGroups:
+  Max: 4

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,6 +32,8 @@ RSpec/ExampleLength:
     - 'spec/lib/slack/block_kit/composition/option_spec.rb'
     - 'spec/lib/slack/block_kit/element/checkboxes_spec.rb'
     - 'spec/lib/slack/block_kit/element/radio_buttons_spec.rb'
+    - 'spec/lib/slack/block_kit/composition/option_spec.rb'
+    - 'spec/lib/slack/block_kit/element/multi_static_select_spec.rb'
 
 # Offense count: 4
 Style/Documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Removed
-- N/A
+- `Slack::BlockKit::Element::Checkboxes#initial`, use the `initial:` keyword on `#option`
+- `Slack::BlockKit::Element::MultiStaticSelect#initial`, use the `initial:` keyword on `#option`
+- `Slack::BlockKit::Element::StaticSelect#initial`, use the `initial:` keyword on `#option`
+
 
 ### Fixed
 - N/A
 
 ### Security
 - N/A
+
+
+---
 
 
 ## [0.11.0] - 2020-10-03
@@ -37,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruby2.7 kwarg deprecation warnings
 
 
+---
+
+
 ## [0.10.0] - 2020-09-11
 
 ### Added
@@ -45,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed initial options in multi select blocks (#46 by @caalberts)
 
+
+---
 
 See [releases] for previous changes.
 

--- a/lib/slack/block_kit/composition/option.rb
+++ b/lib/slack/block_kit/composition/option.rb
@@ -8,11 +8,16 @@ module Slack
       # https://api.slack.com/reference/messaging/composition-objects#option
       # https://api.slack.com/reference/messaging/block-elements#select
       class Option
-        def initialize(value:, text:, emoji: nil, description: nil, url: nil)
+        def initialize(value:, text:, initial: false, emoji: nil, description: nil, url: nil)
           @text = PlainText.new(text: text, emoji: emoji)
           @value = value
           @description = description && PlainText.new(text: description, emoji: emoji)
           @url = url
+          @initial = initial
+        end
+
+        def initial?
+          !!@initial
         end
 
         def as_json(*)

--- a/lib/slack/block_kit/composition/option_group.rb
+++ b/lib/slack/block_kit/composition/option_group.rb
@@ -17,8 +17,8 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(text:, value:, emoji: nil)
-          @options << Option.new(text: text, value: value, emoji: emoji)
+        def option(text:, value:, emoji: nil, initial: false)
+          @options << Option.new(text: text, value: value, emoji: emoji, initial: initial)
 
           self
         end

--- a/lib/slack/block_kit/element/checkboxes.rb
+++ b/lib/slack/block_kit/element/checkboxes.rb
@@ -15,26 +15,16 @@ module Slack
         def initialize(action_id:)
           @action_id = action_id
           @options = []
-          @initial_options = []
 
           yield(self) if block_given?
         end
 
-        def option(value:, text:, description: nil)
+        def option(value:, text:, initial: false, description: nil)
           @options << Composition::Option.new(
             value: value,
             text: text,
-            description: description
-          )
-
-          self
-        end
-
-        def initial(value:, text:, description: nil)
-          @initial_options << Composition::Option.new(
-            value: value,
-            text: text,
-            description: description
+            description: description,
+            initial: initial
           )
 
           self
@@ -45,9 +35,17 @@ module Slack
             type: TYPE,
             action_id: @action_id,
             options: @options.map(&:as_json),
-            initial_options: @initial_options.any? ? @initial_options.map(&:as_json) : nil,
+            initial_options: initial_options&.map(&:as_json),
             confirm: confirm&.as_json
           }.compact
+        end
+
+        private
+
+        def initial_options
+          initial = @options.select(&:initial?)
+
+          initial.empty? ? nil : initial
         end
       end
     end

--- a/lib/slack/block_kit/element/radio_buttons.rb
+++ b/lib/slack/block_kit/element/radio_buttons.rb
@@ -11,10 +11,11 @@ module Slack
 
         TYPE = 'radio_buttons'
 
-        attr_accessor :options, :initial_option
+        attr_accessor :options
 
         def initialize(action_id:)
           @action_id = action_id
+          @options = []
 
           yield(self) if block_given?
         end
@@ -22,13 +23,11 @@ module Slack
         def option(value:, text:, initial: false)
           option = Composition::Option.new(
             value: value,
-            text: text
+            text: text,
+            initial: initial
           )
 
-          @options ||= []
           @options << option
-
-          @initial_option = option if initial
 
           self
         end
@@ -37,10 +36,16 @@ module Slack
           {
             type: TYPE,
             action_id: @action_id,
-            options: @options&.map(&:as_json),
-            initial_option: @initial_option&.as_json,
+            options: @options.map(&:as_json),
+            initial_option: initial_option&.as_json,
             confirm: confirm&.as_json
           }.compact
+        end
+
+        private
+
+        def initial_option
+          @options&.find(&:initial?)
         end
       end
     end

--- a/spec/lib/slack/block_kit/composition/option_group_spec.rb
+++ b/spec/lib/slack/block_kit/composition/option_group_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Slack::BlockKit::Composition::OptionGroup do
         .to change { instance.options.count }.from(0).to(1)
     end
 
+    it 'allows setting options as initial' do
+      instance = described_class.new(label: 'hello')
+      instance.option(text: 'option', value: 'o', initial: true)
+
+      expect(instance.options.first).to be_initial
+    end
+
     it 'appends a Slack::BlockKit::Composition::Option object' do
       instance = described_class.new(label: 'hello')
       expected = Slack::BlockKit::Composition::Option.new(text: 'option', value: 'o')

--- a/spec/lib/slack/block_kit/composition/option_spec.rb
+++ b/spec/lib/slack/block_kit/composition/option_spec.rb
@@ -70,5 +70,27 @@ RSpec.describe Slack::BlockKit::Composition::Option do
         expect(instance.as_json).to eq(expected_hash)
       end
     end
+
+    describe '#initial?' do
+      subject(:initial?) { instance.initial? }
+
+      context 'when default' do
+        let(:instance) { described_class.new(text: 'some text', value: 'a value') }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when initial: true' do
+        let(:instance) do
+          described_class.new(
+            text: 'some text',
+            value: 'a value',
+            initial: true
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end

--- a/spec/lib/slack/block_kit/element/checkboxes_spec.rb
+++ b/spec/lib/slack/block_kit/element/checkboxes_spec.rb
@@ -103,12 +103,9 @@ RSpec.describe Slack::BlockKit::Element::Checkboxes do
       end
 
       it 'correctly serializes' do
-        instance.option(**option)
-        instance.option(**option_description)
+        instance.option(**option.merge(initial: true))
+        instance.option(**option_description.merge(initial: true))
         instance.option(**another_option)
-
-        instance.initial(**option)
-        instance.initial(**option_description)
 
         expect(as_json).to eq(expected_json)
       end

--- a/spec/lib/slack/block_kit/element/static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/static_select_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
+RSpec.describe Slack::BlockKit::Element::StaticSelect do
   let(:instance) { described_class.new(**params) }
   let(:placeholder_text) { 'some text' }
   let(:action_id) { 'my-action' }
@@ -47,16 +47,14 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     ]
   end
 
-  let(:expected_initial_options) do
-    [
-      {
-        text: {
-          text: '__TEXT_2__',
-          type: 'plain_text'
-        },
-        value: '__VALUE_2__'
-      }
-    ]
+  let(:expected_initial_option) do
+    {
+      text: {
+        text: '__TEXT_2__',
+        type: 'plain_text'
+      },
+      value: '__VALUE_2__'
+    }
   end
 
   let(:expected_options) do
@@ -90,7 +88,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
     let(:expected_json) do
       {
-        type: 'multi_static_select',
+        type: 'static_select',
         placeholder: {
           'type': 'plain_text',
           'text': placeholder_text
@@ -112,7 +110,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
       let(:expected_json) do
         {
-          type: 'multi_static_select',
+          type: 'static_select',
           placeholder: {
             'type': 'plain_text',
             'text': placeholder_text
@@ -136,45 +134,6 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
               type: 'plain_text'
             }
           }
-        }
-      end
-
-      it 'correctly serializes' do
-        expect(as_json).to eq(expected_json)
-      end
-    end
-
-    context 'with max_selected_items' do
-      let(:params) do
-        {
-          placeholder: placeholder_text,
-          action_id: action_id,
-          max_selected_items: 10
-        }
-      end
-
-      let(:expected_json) do
-        {
-          type: 'multi_static_select',
-          placeholder: {
-            'type': 'plain_text',
-            'text': placeholder_text
-          },
-          action_id: action_id,
-          max_selected_items: 10
-        }
-      end
-
-      it 'correctly serializes' do
-        expect(as_json).to eq(expected_json)
-      end
-    end
-
-    context 'without max_selected_items' do
-      let(:params) do
-        {
-          placeholder: placeholder_text,
-          action_id: action_id
         }
       end
 
@@ -209,10 +168,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
       it 'correctly serializes' do
         expect(as_json).to eq(
-          expected_json.merge(
-            options: expected_options,
-            initial_options: expected_initial_options
-          )
+          expected_json.merge(options: expected_options, initial_option: expected_initial_option)
         )
       end
     end
@@ -247,10 +203,7 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
       it 'correctly serializes' do
         expect(as_json).to eq(
-          expected_json.merge(
-            option_groups: expected_option_groups,
-            initial_options: expected_initial_options
-          )
+          expected_json.merge(option_groups: expected_option_groups, initial_option: expected_initial_option)
         )
       end
     end


### PR DESCRIPTION
Closes #47

Pass a `initial:` argument to `Option` instead of requiring a separate
call to `#initial`.

Ensures that there is parity between the `initial_option` and `options`.