### PR TITLE
Implement Slack::BlockKit::Element::Timepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Ruby3 Support
+- `Slack::BlockKit::Element::Timepicker` (#72)
 
 ### Changed
 - Development dependencies now managed by bundler via Gemfile, rather than in gemspec

--- a/lib/slack/block_kit/element/timepicker.rb
+++ b/lib/slack/block_kit/element/timepicker.rb
@@ -34,7 +34,6 @@ module Slack
           self
         end
 
-
         def as_json(*)
           {
             type: TYPE,

--- a/lib/slack/block_kit/element/timepicker.rb
+++ b/lib/slack/block_kit/element/timepicker.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Element
+      # An element which allows selection of a time of day.
+      #
+      # On desktop clients, this time picker will take the form of a dropdown
+      # list with free-text entry for precise choices. On mobile clients, the
+      # time picker will use native time picker UIs.
+      #
+      # https://api.slack.com/reference/block-kit/block-elements#timepicker
+      class Timepicker
+        include Composition::ConfirmationDialog::Confirmable
+
+        TYPE = 'timepicker'
+
+        def initialize(action_id:)
+          @placeholder, @initial_time = nil
+          @action_id = action_id
+
+          yield(self) if block_given?
+        end
+
+        def placeholder(text:, emoji: nil)
+          @placeholder = Composition::PlainText.new(text: text, emoji: emoji)
+
+          self
+        end
+
+        def initial_time(time_str)
+          @initial_time = time_str
+
+          self
+        end
+
+
+        def as_json(*)
+          {
+            type: TYPE,
+            action_id: @action_id,
+            placeholder: @placeholder&.as_json,
+            initial_time: @initial_time,
+            confirm: confirm&.as_json
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/timepicker_spec.rb
+++ b/spec/lib/slack/block_kit/element/timepicker_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Element::Timepicker do
+  let(:instance) { described_class.new(action_id: action_id) }
+  let(:type) { 'timepicker' }
+  let(:placeholder) { 'some text' }
+  let(:initial_time) { '11:23' }
+  let(:action_id) { '1123' }
+  let(:placeholder_json) do
+    Slack::BlockKit::Composition::PlainText.new(
+      text: placeholder
+    ).as_json
+  end
+
+  describe '.initialize' do
+    it 'yields self' do
+      yielded = nil
+      new_instance = described_class.new(action_id: action_id) do |timepicker|
+        yielded = timepicker
+      end
+
+      expect(new_instance).to be(yielded)
+    end
+  end
+
+  describe '#placeholder' do
+    it 'returns self' do
+      expect(instance.placeholder(text: placeholder)).to be(instance)
+    end
+  end
+
+  describe '#initial_time' do
+    it 'returns self' do
+      expect(instance.initial_time(initial_time)).to be(instance)
+    end
+  end
+
+  describe '#as_json' do
+    context 'by default' do
+      it 'encodes type and action_id' do
+        expect(instance.as_json).to eq(
+          type: type,
+          action_id: action_id
+        )
+      end
+    end
+
+    context 'with a placeholder' do
+
+      it 'encodes the placeholder object' do
+        instance.placeholder(text: placeholder)
+
+        expect(instance.as_json).to eq(
+          type: type,
+          action_id: action_id,
+          placeholder: placeholder_json
+        )
+      end
+    end
+
+    context 'with initial_time' do
+      it 'encodes the initial_time' do
+        instance.initial_time(initial_time)
+
+        expect(instance.as_json).to eq(
+          type: type,
+          action_id: action_id,
+          initial_time: initial_time
+        )
+      end
+    end
+
+    context 'with placeholder and initial_time' do
+      it 'encodes the placeholder & initial_time' do
+        instance.placeholder(text: placeholder)
+        instance.initial_time(initial_time)
+
+        expect(instance.as_json).to eq(
+          type: type,
+          action_id: action_id,
+          initial_time: initial_time,
+          placeholder: placeholder_json
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/timepicker_spec.rb
+++ b/spec/lib/slack/block_kit/element/timepicker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
   end
 
   describe '#as_json' do
-    context 'by default' do
+    context 'when minimal use case' do
       it 'encodes type and action_id' do
         expect(instance.as_json).to eq(
           type: type,
@@ -48,41 +48,52 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
     end
 
     context 'with a placeholder' do
+      let(:expected_json) do
+        {
+          type: type,
+          action_id: action_id,
+          placeholder: placeholder_json
+        }
+      end
 
       it 'encodes the placeholder object' do
         instance.placeholder(text: placeholder)
 
-        expect(instance.as_json).to eq(
-          type: type,
-          action_id: action_id,
-          placeholder: placeholder_json
-        )
+        expect(instance.as_json).to eq(expected_json)
       end
     end
 
     context 'with initial_time' do
-      it 'encodes the initial_time' do
-        instance.initial_time(initial_time)
-
-        expect(instance.as_json).to eq(
+      let(:expected_json) do
+        {
           type: type,
           action_id: action_id,
           initial_time: initial_time
-        )
+        }
+      end
+
+      it 'encodes the initial_time' do
+        instance.initial_time(initial_time)
+
+        expect(instance.as_json).to eq(expected_json)
       end
     end
 
     context 'with placeholder and initial_time' do
-      it 'encodes the placeholder & initial_time' do
-        instance.placeholder(text: placeholder)
-        instance.initial_time(initial_time)
-
-        expect(instance.as_json).to eq(
+      let(:expected_json) do
+        {
           type: type,
           action_id: action_id,
           initial_time: initial_time,
           placeholder: placeholder_json
-        )
+        }
+      end
+
+      it 'encodes the placeholder & initial_time' do
+        instance.placeholder(text: placeholder)
+        instance.initial_time(initial_time)
+
+        expect(instance.as_json).to eq(expected_json)
       end
     end
   end


### PR DESCRIPTION
Adds support for the [timepicker] element recently released for general
use.

[timepicker]: https://api.slack.com/reference/block-kit/block-elements#timepicker

Signed-off-by: Christian Gregg <christian@bissy.io>