### PR TITLE
Add header helper to Blocks

### DIFF
--- a/lib/slack/block_kit/blocks.rb
+++ b/lib/slack/block_kit/blocks.rb
@@ -37,6 +37,12 @@ module Slack
         append(block)
       end
 
+      def header(text:, block_id: nil, emoji: nil)
+        block = Layout::Header.new(text: text, block_id: block_id, emoji: emoji)
+
+        append(block)
+      end
+
       def image(url:, alt_text:, title: nil, block_id: nil, emoji: nil)
         block = Layout::Image.new(
           url: url,


### PR DESCRIPTION
Adds missing `header` helper to take advantage of `Layout::Header` from
https://github.com/CGA1123/slack-ruby-block-kit/pull/57.