### PR TITLE
Fixed section to support fields with no additional text.

### DIFF
--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -186,7 +186,7 @@ module Slack
         def as_json(*)
           {
             type: TYPE,
-            text: @text.as_json,
+            text: @text&.as_json,
             block_id: @block_id,
             fields: @fields&.map(&:as_json),
             accessory: @accessory&.as_json

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -188,11 +188,9 @@ RSpec.describe Slack::BlockKit::Layout::Section do
     end
   end
 
-  context 'fields with text' do
-
+  context 'with fields and text' do
     describe '#plaintext_field' do
-
-      let (:expected_plaintext_field_json) do
+      let(:expected_plaintext_field_json) do
         {
           emoji: false,
           text: '__FIELD_TEXT__',
@@ -203,13 +201,12 @@ RSpec.describe Slack::BlockKit::Layout::Section do
       it 'correctly serializes' do
         instance.plaintext_field(text: '__FIELD_TEXT__', emoji: false)
 
-        expect(section_json).to eq(expected_json.merge(fields: [ expected_plaintext_field_json ]))
+        expect(section_json).to eq(expected_json.merge(fields: [expected_plaintext_field_json]))
       end
-
     end
 
     describe '#mrkdwn_field' do
-      let (:expected_mrkdwn_field_json) do
+      let(:expected_mrkdwn_field_json) do
         {
           verbatim: false,
           text: '__FIELD_MRKDWN__',
@@ -220,13 +217,12 @@ RSpec.describe Slack::BlockKit::Layout::Section do
       it 'correctly serializes' do
         instance.mrkdwn_field(text: '__FIELD_MRKDWN__', verbatim: false)
 
-        expect(section_json).to eq(expected_json.merge(fields: [ expected_mrkdwn_field_json ]))
+        expect(section_json).to eq(expected_json.merge(fields: [expected_mrkdwn_field_json]))
       end
     end
-
   end
 
-  context 'fields with no text' do
+  context 'with fields but no text' do
     let(:instance) do
       block = described_class.new(block_id: '__BLOCK__')
       block
@@ -239,7 +235,7 @@ RSpec.describe Slack::BlockKit::Layout::Section do
     end
 
     describe 'single #mrkdwn_field' do
-      let (:expected_mrkdwn_field_json) do
+      let(:expected_mrkdwn_field_json) do
         {
           verbatim: false,
           text: '__FIELD_MRKDWN__',
@@ -250,9 +246,8 @@ RSpec.describe Slack::BlockKit::Layout::Section do
       it 'correctly serializes' do
         instance.mrkdwn_field(text: '__FIELD_MRKDWN__', verbatim: false)
 
-        expect(section_json).to eq(expected_json.merge(fields: [ expected_mrkdwn_field_json ]))
+        expect(section_json).to eq(expected_json.merge(fields: [expected_mrkdwn_field_json]))
       end
     end
   end
-
 end

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -223,10 +223,7 @@ RSpec.describe Slack::BlockKit::Layout::Section do
   end
 
   context 'with fields but no text' do
-    let(:instance) do
-      block = described_class.new(block_id: '__BLOCK__')
-      block
-    end
+    let(:instance) { described_class.new(block_id: '__BLOCK__') }
     let(:expected_json) do
       {
         block_id: '__BLOCK__',

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -187,4 +187,72 @@ RSpec.describe Slack::BlockKit::Layout::Section do
       expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
     end
   end
+
+  context 'fields with text' do
+
+    describe '#plaintext_field' do
+
+      let (:expected_plaintext_field_json) do
+        {
+          emoji: false,
+          text: '__FIELD_TEXT__',
+          type: 'plain_text'
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.plaintext_field(text: '__FIELD_TEXT__', emoji: false)
+
+        expect(section_json).to eq(expected_json.merge(fields: [ expected_plaintext_field_json ]))
+      end
+
+    end
+
+    describe '#mrkdwn_field' do
+      let (:expected_mrkdwn_field_json) do
+        {
+          verbatim: false,
+          text: '__FIELD_MRKDWN__',
+          type: 'mrkdwn'
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.mrkdwn_field(text: '__FIELD_MRKDWN__', verbatim: false)
+
+        expect(section_json).to eq(expected_json.merge(fields: [ expected_mrkdwn_field_json ]))
+      end
+    end
+
+  end
+
+  context 'fields with no text' do
+    let(:instance) do
+      block = described_class.new(block_id: '__BLOCK__')
+      block
+    end
+    let(:expected_json) do
+      {
+        block_id: '__BLOCK__',
+        type: 'section'
+      }
+    end
+
+    describe 'single #mrkdwn_field' do
+      let (:expected_mrkdwn_field_json) do
+        {
+          verbatim: false,
+          text: '__FIELD_MRKDWN__',
+          type: 'mrkdwn'
+        }
+      end
+
+      it 'correctly serializes' do
+        instance.mrkdwn_field(text: '__FIELD_MRKDWN__', verbatim: false)
+
+        expect(section_json).to eq(expected_json.merge(fields: [ expected_mrkdwn_field_json ]))
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
In the current implementation, the following code would fail to render as JSON:
```
blocks = Slack::BlockKit.blocks do |b|
  b.section do |s|
    s.mrkdwn_field(text: "Some markdown")
    s.mrkdwn_field(text: "More markdown")
  end
end
```
although this is supported in BlockKit.

This PR fixes that, and adds some specs to test this and a few other missing cases from section.rb.