### PR TITLE
support dispatch_action on input blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fixed
-- N/A
+- Support `dispatch_action` configuration on `Layout::Input`
 
 ### Security
 - N/A

--- a/lib/slack/block_kit/blocks.rb
+++ b/lib/slack/block_kit/blocks.rb
@@ -63,11 +63,12 @@ module Slack
         append(block)
       end
 
-      def input(label:, hint: nil, block_id: nil)
+      def input(label:, hint: nil, block_id: nil, dispatch_action: nil)
         block = Layout::Input.new(
           label: label,
           hint: hint,
-          block_id: block_id
+          block_id: block_id,
+          dispatch_action: dispatch_action
         )
 
         yield(block) if block_given?

--- a/lib/slack/block_kit/composition/dispatch_action_configuration.rb
+++ b/lib/slack/block_kit/composition/dispatch_action_configuration.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Composition
+      # Determines when a plain-text input element will return a block_actions
+      # interaction payload.
+      #
+      # @param [Array] triggers - values for the `trigger_actions_on` array
+      #
+      # https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+      # https://api.slack.com/reference/block-kit/block-elements#input
+      class DispatchActionConfiguration
+        def initialize(triggers: nil)
+          @triggers = triggers || []
+        end
+
+        def trigger_on_enter_pressed
+          @triggers << :on_enter_pressed
+        end
+
+        def trigger_on_character_entered
+          @triggers << :on_character_entered
+        end
+
+        def as_json(*)
+          {
+            trigger_actions_on: @triggers.uniq
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/slack/block_kit/element/plain_text_input.rb
+++ b/lib/slack/block_kit/element/plain_text_input.rb
@@ -30,6 +30,14 @@ module Slack
           @max_length = max_length
         end
 
+        def dispatch_action_config(triggers: nil)
+          @dispatch_action_config = Composition::DispatchActionConfiguration.new(triggers: triggers)
+
+          yield(@dispatch_action_config) if block_given?
+
+          self
+        end
+
         def as_json(*)
           {
             type: TYPE,
@@ -38,7 +46,8 @@ module Slack
             multiline: @multiline,
             min_length: @min_length,
             max_length: @max_length,
-            initial_value: @initial_value
+            initial_value: @initial_value,
+            dispatch_action_config: @dispatch_action_config&.as_json
           }.compact
         end
       end

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -19,13 +19,15 @@ module Slack
           block_id: nil,
           hint: nil,
           optional: nil,
-          emoji: nil
+          emoji: nil,
+          dispatch_action: nil
         )
           @label = Composition::PlainText.new(text: label, emoji: emoji) if label
           @hint = Composition::PlainText.new(text: hint, emoji: emoji) if hint
           @block_id = block_id
           @optional = optional
           @element = element
+          @dispatch_action = dispatch_action
         end
 
         def conversation_select(placeholder:, action_id:, initial: nil, emoji: nil)
@@ -228,7 +230,8 @@ module Slack
             label: @label&.as_json,
             hint: @hint&.as_json,
             block_id: @block_id,
-            optional: optional
+            optional: optional,
+            dispatch_action: @dispatch_action
           }.compact
         end
       end

--- a/spec/lib/slack/block_kit/composition/dispatch_action_configuration_spec.rb
+++ b/spec/lib/slack/block_kit/composition/dispatch_action_configuration_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Composition::DispatchActionConfiguration do
+  describe '#trigger_on_enter_pressed' do
+    it 'includes the correct trigger' do
+      instance = described_class.new
+      instance.trigger_on_enter_pressed
+      expected_hash = { trigger_actions_on: [:on_enter_pressed] }
+
+      expect(instance.as_json).to eq(expected_hash)
+    end
+  end
+
+  describe '#trigger_on_character_entered' do
+    it 'includes the correct trigger' do
+      instance = described_class.new
+      instance.trigger_on_character_entered
+      expected_hash = { trigger_actions_on: [:on_character_entered] }
+
+      expect(instance.as_json).to eq(expected_hash)
+    end
+  end
+
+  describe '#as_json' do
+    context 'when triggers are passed into the constructor' do
+      it 'includes the correct triggers' do
+        instance = described_class.new(triggers: [:on_enter_pressed])
+        expected_hash = { trigger_actions_on: [:on_enter_pressed] }
+
+        expect(instance.as_json).to eq(expected_hash)
+      end
+    end
+
+    context 'when added using the methods' do
+      it 'includes to correct triggers' do
+        instance = described_class.new
+        instance.trigger_on_enter_pressed
+        instance.trigger_on_character_entered
+        expected_hash = { trigger_actions_on: [:on_enter_pressed, :on_character_entered] }
+
+        expect(instance.as_json).to eq(expected_hash)
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/element/plain_text_input_spec.rb
+++ b/spec/lib/slack/block_kit/element/plain_text_input_spec.rb
@@ -23,6 +23,41 @@ RSpec.describe Slack::BlockKit::Element::PlainTextInput do
     }
   end
 
+  describe '#dispatch_action_config' do
+    let(:expected_json) do
+      {
+        type: 'plain_text_input',
+        action_id: action_id,
+        initial_value: initial_value,
+        min_length: min_length,
+        max_length: max_length,
+        multiline: multiline,
+        placeholder: Slack::BlockKit::Composition::PlainText.new(text: placeholder, emoji: emoji).as_json,
+        dispatch_action_config: Slack::BlockKit::Composition::DispatchActionConfiguration.new(
+          triggers: [:on_enter_pressed]
+        ).as_json
+      }
+    end
+
+    context 'when passing in triggers directly' do
+      it 'generates the correct output' do
+        instance.dispatch_action_config(triggers: [:on_enter_pressed])
+
+        expect(instance.as_json).to eq(expected_json)
+      end
+    end
+
+    context 'when passing a block' do
+      it 'generates the correct output' do
+        instance.dispatch_action_config do |config|
+          config.trigger_on_enter_pressed
+        end
+
+        expect(instance.as_json).to eq(expected_json)
+      end
+    end
+  end
+
   describe '#as_json' do
     subject { instance.as_json }
 

--- a/spec/lib/slack/block_kit/layout/input_spec.rb
+++ b/spec/lib/slack/block_kit/layout/input_spec.rb
@@ -254,5 +254,33 @@ RSpec.describe Slack::BlockKit::Layout::Input do
     end
 
     it { is_expected.to eq(expected_json) }
+
+    context 'when dispatch_action is set' do
+      let(:params) do
+        {
+          optional: optional,
+          element: element,
+          hint: hint,
+          label: label,
+          block_id: block_id,
+          emoji: emoji,
+          dispatch_action: true
+        }
+      end
+
+      let(:expected_json) do
+        {
+          type: 'input',
+          optional: optional,
+          block_id: block_id,
+          element: element_json,
+          hint: Slack::BlockKit::Composition::PlainText.new(text: hint, emoji: emoji).as_json,
+          label: Slack::BlockKit::Composition::PlainText.new(text: label, emoji: emoji).as_json,
+          dispatch_action: true
+        }
+      end
+
+      it { is_expected.to eq(expected_json) }
+    end
   end
 end


### PR DESCRIPTION
The `dispatches_action` option on [Input](https://api.slack.com/reference/block-kit/blocks#input_fields) and the `dispatch_action_config` on [Plain-Text Input](https://api.slack.com/reference/block-kit/block-elements#input) weren't able to be set before. It seems to be a pretty simple addition.