### PR TITLE
Fix typo in method name "converstation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Deprecated
-- N/A
+- `Layout::Actions#converstation_select` (use `#conversation_select` instead)
 
 ### Removed
 - N/A
 
 ### Fixed
-- N/A
+- Fixed name of method in `Layout::Actions` to be `conversation_select`
 
 ### Security
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Deprecated
-- `Layout::Actions#converstation_select` (use `#conversation_select` instead)
+- N/A
 
 ### Removed
-- N/A
+- `Layout::Actions#converstation_select` (use `#conversation_select` instead)
 
 ### Fixed
 - Fixed name of method in `Layout::Actions` to be `conversation_select`

--- a/lib/slack/block_kit/layout/actions.rb
+++ b/lib/slack/block_kit/layout/actions.rb
@@ -46,7 +46,7 @@ module Slack
           append(element)
         end
 
-        def converstation_select(placeholder:, action_id:, initial: nil, emoji: nil)
+        def conversation_select(placeholder:, action_id:, initial: nil, emoji: nil)
           element = Element::ConversationsSelect.new(
             placeholder: placeholder,
             action_id: action_id,

--- a/lib/slack/block_kit/layout/actions.rb
+++ b/lib/slack/block_kit/layout/actions.rb
@@ -142,11 +142,6 @@ module Slack
             block_id: @block_id
           }.compact
         end
-
-        # Maintain backwards compatibility with previously misspelled name
-        extend Gem::Deprecate
-        alias converstation_select conversation_select
-        deprecate :converstation_select, :conversation_select, 2021, 7
       end
     end
   end

--- a/lib/slack/block_kit/layout/actions.rb
+++ b/lib/slack/block_kit/layout/actions.rb
@@ -142,6 +142,11 @@ module Slack
             block_id: @block_id
           }.compact
         end
+
+        # Maintain backwards compatibility with previously misspelled name
+        extend Gem::Deprecate
+        alias converstation_select conversation_select
+        deprecate :converstation_select, :conversation_select, 2021, 7
       end
     end
   end

--- a/spec/lib/slack/block_kit/layout/actions_spec.rb
+++ b/spec/lib/slack/block_kit/layout/actions_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Slack::BlockKit::Layout::Actions do
     end
 
     it 'correctly serializes' do
-      instance.converstation_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+      instance.conversation_select(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
 
       expected_json[:elements] << expected_element_json
       expect(actions_json).to eq(expected_json)


### PR DESCRIPTION
`Layout::Actions` has a typo in the method name `converstation_select` which should be `conversation_select`. This fixes it in the first commit, but also provides a second (optional) commit that keeps the existing behaviour but marks it as deprecated. Since this library is pre 1.0 it's totally reasonable to ship it without the backwards compatibility, but wanted to leave it up to the maintainers to decide on whether or not to include it 🙂