### PR TITLE
Implement Slack::BlockKit::Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- `Slack::BlockKit::Formatting` with utility functions for Slack text formatting (#98 by @CGA1123)
 
 ### Changed
 - N/A

--- a/lib/slack/block_kit/formatting.rb
+++ b/lib/slack/block_kit/formatting.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    # Formatting contains some utility functions to help formatting text
+    #
+    # See: https://api.slack.com/reference/surfaces/formatting
+    module Formatting
+      extend self # rubocop:disable Style/ModuleFunction
+
+      DATE_FORMAT_TOKENS = [
+        # 2014-02-18
+        DATE_NUM = '{date_num}',
+
+        # February 18th, 2014
+        DATE = '{date}',
+
+        # Feb 18, 2014
+        DATE_SHORT = '{date_short}',
+
+        # Tuesday, February 18th, 2014
+        DATE_LONG = '{date_long}',
+
+        # February 18th, 2014 but uses "yesterday", "today", or "tomorrow"
+        # where
+        # appropriate
+        DATE_PRETTY = '{date_pretty}',
+
+        # Feb 18, 2014 but uses "yesterday", "today", or "tomorrow" where
+        # appropriate
+        DATE_SHORT_PRETTY = '{date_short_pretty}',
+
+        # Tuesday, February 18th, 2014 but uses "yesterday", "today", or
+        # "tomorrow" where appropriate
+        DATE_LONG_PRETTY = '{date_long_pretty}',
+
+        # 6:39 AM or 6:39 PM / 06:39 or 18:39 (depending on user preferences)
+        TIME = '{time}',
+
+        # 6:39:45 AM 6:39:42 PM / 06:39:45 or 18:39:42 (depending on user
+        # preferences)
+        TIME_SECS = '{time_secs}'
+      ].freeze
+
+      # Format a URL
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#links
+      def link(url, link_text: nil)
+        "<#{[url, link_text].compact.join('|')}>"
+      end
+
+      # Format a mailto link
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#links
+      def mailto(address, link_text: nil)
+        "<mailto:#{[address, link_text].compact.join('|')}>"
+      end
+
+      # Link a public channel
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#linking-channels
+      def channel(identifier)
+        "<##{identifier}>"
+      end
+
+      # Mention a user
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#mentioning-users
+      def user(identifier)
+        "<@#{identifier}>"
+      end
+
+      # Mention a group
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#mentioning-groups
+      def group(identifier)
+        "<!subteam^#{identifier}>"
+      end
+
+      # Mention @here (all active users in the current channel)
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#special-mentions
+      def at_here
+        # additional "|here" is for supporting very old mobile clients apparently!
+        '<!here|here>'
+      end
+
+      # Mention @channel (all users in the current channel)
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#special-mentions
+      def at_channel
+        '<!channel>'
+      end
+
+      # Mention @everyone (all users in #general)
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#special-mentions
+      def at_everyone
+        '<!everyone>'
+      end
+
+      # Localise a UNIX timestamp to the user's local timezone
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#date-formatting
+      def date(timestamp, token_string:, link: nil, fallback_text: nil)
+        datetime_str = [timestamp, token_string, link].compact.join('^')
+        str = [datetime_str, fallback_text].compact.join('|')
+
+        "<!date^#{str}>"
+      end
+
+      # Escape special characters (<,>,&) with their HTML entity code so
+      # Slack's text parsers knows to interpret them as literals.
+      #
+      # See: https://api.slack.com/reference/surfaces/formatting#escaping
+      def escape(text)
+        text
+          .gsub('&', '&amp;')
+          .gsub('>', '&gt;')
+          .gsub('<', '&lt;')
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/formatting_spec.rb
+++ b/spec/lib/slack/block_kit/formatting_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Formatting do
+  shared_examples 'formatting helpers' do |klass|
+    describe '#link' do
+      context 'with no link_text' do
+        subject { klass.link('https://github.com') }
+
+        it { is_expected.to eq('<https://github.com>') }
+      end
+
+      context 'with link_text' do
+        subject { klass.link('https://github.com', link_text: 'GitHub') }
+
+        it { is_expected.to eq('<https://github.com|GitHub>') }
+      end
+    end
+
+    describe '#mailto' do
+      context 'with no link_text' do
+        subject { klass.mailto('foo@bar.com') }
+
+        it { is_expected.to eq('<mailto:foo@bar.com>') }
+      end
+
+      context 'with link_text' do
+        subject { klass.mailto('foo@bar.com', link_text: 'Email Foo Bar') }
+
+        it { is_expected.to eq('<mailto:foo@bar.com|Email Foo Bar>') }
+      end
+    end
+
+    describe '#channel' do
+      subject { klass.channel('C024BE7LR') }
+
+      it { is_expected.to eq('<#C024BE7LR>') }
+    end
+
+    describe '#user' do
+      subject { klass.user('U024BE7LH') }
+
+      it { is_expected.to eq('<@U024BE7LH>') }
+    end
+
+    describe '#group' do
+      subject { klass.group('SAZ94GDB8') }
+
+      it { is_expected.to eq('<!subteam^SAZ94GDB8>') }
+    end
+
+    describe '#at_here' do
+      subject { klass.at_here }
+
+      it { is_expected.to eq('<!here|here>') }
+    end
+
+    describe '#at_channel' do
+      subject { klass.at_channel }
+
+      it { is_expected.to eq('<!channel>') }
+    end
+
+    describe '#at_everyone' do
+      subject { klass.at_everyone }
+
+      it { is_expected.to eq('<!everyone>') }
+    end
+
+    describe '#date' do
+      let(:timestamp) { 1_392_734_382 }
+      let(:token_string) { 'Posted {date_num} {time_secs}' }
+      let(:fallback_text) { 'Posted 2014-02-18 6:39:42 AM PST' }
+
+      context 'with no link' do
+        subject do
+          klass.date(
+            timestamp,
+            token_string: token_string,
+            fallback_text: fallback_text
+          )
+        end
+
+        it { is_expected.to eq('<!date^1392734382^Posted {date_num} {time_secs}|Posted 2014-02-18 6:39:42 AM PST>') }
+      end
+
+      context 'with a link' do
+        subject do
+          klass.date(
+            timestamp,
+            token_string: token_string,
+            fallback_text: fallback_text,
+            link: 'https://example.com/'
+          )
+        end
+
+        let(:expected) do
+          '<!date^1392734382^Posted {date_num} {time_secs}^https://example.com/|Posted 2014-02-18 6:39:42 AM PST>'
+        end
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+
+    describe '#escape' do
+      subject { klass.escape(text) }
+
+      let(:text) { '<span>hello</span> these should be escaped & this as well!' }
+      let(:expected) { '&lt;span&gt;hello&lt;/span&gt; these should be escaped &amp; this as well!' }
+
+      it { is_expected.to eq(expected) }
+    end
+  end
+
+  describe 'when extendind a class' do
+    include_examples 'formatting helpers', Class.new.extend(described_class)
+  end
+
+  describe 'when calling directly' do
+    include_examples 'formatting helpers', described_class
+  end
+end


### PR DESCRIPTION
Adds `Slack::BlockKit::Formatting` which provides some utility
functions for Slack specific text formatting.

See: https://api.slack.com/reference/surfaces/formatting