### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
       - run: git config --global user.name GitHub Actions
       - run: git config --global user.password ${{ github.token }}
       - run: bundle install
-      - run: git status
-      - run: git diff
       - run: bundle exec rake release
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      otp:
+        name: 'RubyGems OTP Code'
+        required: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - run: gem update --system
+      - run: git config --global user.email github-action@users.noreply.github.com
+      - run: git config --global user.name GitHub Actions
+      - run: git config --global user.password ${{ github.token }}
+      - run: bundle install
+      - run: git status
+      - run: git diff
+      - run: bundle exec rake release
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          GEM_HOST_OTP_CODE: ${{ github.event.inputs.otp }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   codecov (~> 0.5)


### PR DESCRIPTION
Since the latest version of RubyGems supports passing OTP codes via an
environment variable, this means releases are a bit easier and can be
automated via a GitHub Actions workflow.

Ideally I would extend this to autogenerate the CHANGELOG file and
create a GitHub Release based on the tag as well.

See: rubygems/rubygems#4697