### PR TITLE
Make Datepicker and Timepicker more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- `Slack::BlockKit::Layout::Input#Timepicker`
+- `Slack::BlockKit::Layout::Actions#timepicker`
+- `Slack::BlockKit::Layout::Section#timepicker`
 
 ### Changed
-- N/A
+- `Slack::BlockKit::Element::Timepicker.initialize` now accepts `initial:`, `emoji:`, `placeholder:`
+- Rename `Slack::BlockKit::Element::DatePicker` to `Datepicker`
+- Rename `Slack::BlockKit::Layout::Actions#date_picker` to `#datepicker`
+- Rename `Slack::BlockKit::Layout::Section#date_picker` to `#datepicker`
+- 
 
 ### Deprecated
 - N/A
 
 ### Removed
-- N/A
+- `Slack::BlockKit::Element::Timepicker#placeholder`
+- `Slack::BlockKit::Element::Timepicker#initial_time`
 
 ### Fixed
 - N/A

--- a/lib/slack/block_kit/element/datepicker.rb
+++ b/lib/slack/block_kit/element/datepicker.rb
@@ -9,7 +9,7 @@ module Slack
       # Date picker elements can be used inside of section and actions blocks.
       #
       # https://api.slack.com/reference/messaging/block-elements#datepicker
-      class DatePicker
+      class Datepicker
         include Composition::ConfirmationDialog::Confirmable
 
         TYPE = 'datepicker'

--- a/lib/slack/block_kit/element/timepicker.rb
+++ b/lib/slack/block_kit/element/timepicker.rb
@@ -15,23 +15,12 @@ module Slack
 
         TYPE = 'timepicker'
 
-        def initialize(action_id:)
-          @placeholder, @initial_time = nil
+        def initialize(action_id:, placeholder: nil, initial: nil, emoji: nil)
+          @placeholder = placeholder_text(placeholder, emoji) if placeholder
+          @initial_time = initial
           @action_id = action_id
 
           yield(self) if block_given?
-        end
-
-        def placeholder(text:, emoji: nil)
-          @placeholder = Composition::PlainText.new(text: text, emoji: emoji)
-
-          self
-        end
-
-        def initial_time(time_str)
-          @initial_time = time_str
-
-          self
         end
 
         def as_json(*)
@@ -42,6 +31,14 @@ module Slack
             initial_time: @initial_time,
             confirm: confirm&.as_json
           }.compact
+        end
+
+        private
+
+        def placeholder_text(text, emoji)
+          return unless text
+
+          Composition::PlainText.new(text: text, emoji: emoji)
         end
       end
     end

--- a/lib/slack/block_kit/layout/actions.rb
+++ b/lib/slack/block_kit/layout/actions.rb
@@ -59,8 +59,21 @@ module Slack
           append(element)
         end
 
-        def date_picker(action_id:, placeholder: nil, initial: nil, emoji: nil)
-          element = Element::DatePicker.new(
+        def datepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
+          element = Element::Datepicker.new(
+            placeholder: placeholder,
+            action_id: action_id,
+            initial: initial,
+            emoji: emoji
+          )
+
+          yield(element) if block_given?
+
+          append(element)
+        end
+
+        def timepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
+          element = Element::Timepicker.new(
             placeholder: placeholder,
             action_id: action_id,
             initial: initial,

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -79,7 +79,7 @@ module Slack
         end
 
         def datepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
-          @element = Element::DatePicker.new(
+          @element = Element::Datepicker.new(
             action_id: action_id,
             placeholder: placeholder,
             initial: initial,
@@ -92,9 +92,12 @@ module Slack
         end
 
         def timepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
-          @element = Element::Timepicker.new(action_id: action_id)
-          @element.placeholder(text: placeholder, emoji: emoji)
-          @element.initial_time(initial)
+          @element = Element::Timepicker.new(
+            action_id: action_id,
+            placeholder: placeholder,
+            emoji: emoji,
+            initial: initial
+          )
 
           yield(@element) if block_given?
 

--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -94,8 +94,21 @@ module Slack
           accessorise(element)
         end
 
-        def date_picker(action_id:, placeholder: nil, initial: nil, emoji: nil)
-          element = Element::DatePicker.new(
+        def datepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
+          element = Element::Datepicker.new(
+            placeholder: placeholder,
+            action_id: action_id,
+            initial: initial,
+            emoji: emoji
+          )
+
+          yield(element) if block_given?
+
+          accessorise(element)
+        end
+
+        def timepicker(action_id:, placeholder: nil, initial: nil, emoji: nil)
+          element = Element::Timepicker.new(
             placeholder: placeholder,
             action_id: action_id,
             initial: initial,

--- a/spec/lib/slack/block_kit/element/timepicker_spec.rb
+++ b/spec/lib/slack/block_kit/element/timepicker_spec.rb
@@ -3,21 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Slack::BlockKit::Element::Timepicker do
-  let(:instance) { described_class.new(action_id: action_id) }
-  let(:type) { 'timepicker' }
-  let(:placeholder) { 'some text' }
-  let(:initial_time) { '11:23' }
-  let(:action_id) { '1123' }
-  let(:placeholder_json) do
-    Slack::BlockKit::Composition::PlainText.new(
-      text: placeholder
-    ).as_json
-  end
-
   describe '.initialize' do
     it 'yields self' do
       yielded = nil
-      new_instance = described_class.new(action_id: action_id) do |timepicker|
+      new_instance = described_class.new(action_id: '1123') do |timepicker|
         yielded = timepicker
       end
 
@@ -25,24 +14,14 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
     end
   end
 
-  describe '#placeholder' do
-    it 'returns self' do
-      expect(instance.placeholder(text: placeholder)).to be(instance)
-    end
-  end
-
-  describe '#initial_time' do
-    it 'returns self' do
-      expect(instance.initial_time(initial_time)).to be(instance)
-    end
-  end
-
   describe '#as_json' do
     context 'when minimal use case' do
       it 'encodes type and action_id' do
+        instance = described_class.new(action_id: '1123')
+
         expect(instance.as_json).to eq(
-          type: type,
-          action_id: action_id
+          type: 'timepicker',
+          action_id: '1123'
         )
       end
     end
@@ -50,14 +29,17 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
     context 'with a placeholder' do
       let(:expected_json) do
         {
-          type: type,
-          action_id: action_id,
-          placeholder: placeholder_json
+          type: 'timepicker',
+          action_id: '1123',
+          placeholder: Slack::BlockKit::Composition::PlainText.new(text: 'pick a time').as_json
         }
       end
 
       it 'encodes the placeholder object' do
-        instance.placeholder(text: placeholder)
+        instance = described_class.new(
+          action_id: '1123',
+          placeholder: 'pick a time'
+        )
 
         expect(instance.as_json).to eq(expected_json)
       end
@@ -66,14 +48,17 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
     context 'with initial_time' do
       let(:expected_json) do
         {
-          type: type,
-          action_id: action_id,
-          initial_time: initial_time
+          type: 'timepicker',
+          action_id: '1123',
+          initial_time: '11:23'
         }
       end
 
       it 'encodes the initial_time' do
-        instance.initial_time(initial_time)
+        instance = described_class.new(
+          action_id: '1123',
+          initial: '11:23'
+        )
 
         expect(instance.as_json).to eq(expected_json)
       end
@@ -82,16 +67,19 @@ RSpec.describe Slack::BlockKit::Element::Timepicker do
     context 'with placeholder and initial_time' do
       let(:expected_json) do
         {
-          type: type,
-          action_id: action_id,
-          initial_time: initial_time,
-          placeholder: placeholder_json
+          type: 'timepicker',
+          action_id: '1123',
+          initial_time: '11:23',
+          placeholder: Slack::BlockKit::Composition::PlainText.new(text: 'pick a time').as_json
         }
       end
 
       it 'encodes the placeholder & initial_time' do
-        instance.placeholder(text: placeholder)
-        instance.initial_time(initial_time)
+        instance = described_class.new(
+          action_id: '1123',
+          initial: '11:23',
+          placeholder: 'pick a time'
+        )
 
         expect(instance.as_json).to eq(expected_json)
       end

--- a/spec/lib/slack/block_kit/layout/actions_spec.rb
+++ b/spec/lib/slack/block_kit/layout/actions_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Slack::BlockKit::Layout::Actions do
     end
   end
 
-  describe '#date_picker' do
+  describe '#datepicker' do
     let(:expected_element_json) do
       {
         action_id: '__ACTION_ID__',
@@ -93,7 +93,7 @@ RSpec.describe Slack::BlockKit::Layout::Actions do
     end
 
     it 'correctly serializes' do
-      instance.date_picker(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+      instance.datepicker(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
 
       expected_json[:elements] << expected_element_json
       expect(actions_json).to eq(expected_json)

--- a/spec/lib/slack/block_kit/layout/input_spec.rb
+++ b/spec/lib/slack/block_kit/layout/input_spec.rb
@@ -94,13 +94,27 @@ RSpec.describe Slack::BlockKit::Layout::Input do
 
   describe '#datepicker' do
     let(:element_json) do
-      Slack::BlockKit::Element::DatePicker.new(
+      Slack::BlockKit::Element::Datepicker.new(
         action_id: '__ACTION_ID__'
       ).as_json
     end
 
     it 'correctly serializes' do
       instance.datepicker(action_id: '__ACTION_ID__')
+
+      expect(input_json).to eq(expected_json)
+    end
+  end
+
+  describe '#timepicker' do
+    let(:element_json) do
+      Slack::BlockKit::Element::Timepicker.new(
+        action_id: '__ACTION_ID__'
+      ).as_json
+    end
+
+    it 'correctly serializes' do
+      instance.timepicker(action_id: '__ACTION_ID__')
 
       expect(input_json).to eq(expected_json)
     end

--- a/spec/lib/slack/block_kit/layout/section_spec.rb
+++ b/spec/lib/slack/block_kit/layout/section_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Slack::BlockKit::Layout::Section do
     end
   end
 
-  describe '#date_picker' do
+  describe '#datepicker' do
     let(:expected_accessory_json) do
       {
         action_id: '__ACTION_ID__',
@@ -115,7 +115,26 @@ RSpec.describe Slack::BlockKit::Layout::Section do
     end
 
     it 'correctly serializes' do
-      instance.date_picker(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+      instance.datepicker(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
+
+      expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
+    end
+  end
+
+  describe '#timepicker' do
+    let(:expected_accessory_json) do
+      {
+        action_id: '__ACTION_ID__',
+        placeholder: {
+          text: '__PLACEHOLDER__',
+          type: 'plain_text'
+        },
+        type: 'timepicker'
+      }
+    end
+
+    it 'correctly serializes' do
+      instance.timepicker(placeholder: '__PLACEHOLDER__', action_id: '__ACTION_ID__')
 
       expect(section_json).to eq(expected_json.merge(accessory: expected_accessory_json))
     end


### PR DESCRIPTION
* Rename `DatePicker` to `Datepicker`
* Remove `Timepicker#initial_time` + `Timepicker#placeholder`, inject
  them in initializer instead.
* Rename `#date_picker` to `#datepicker`
* Add `#timepicker` helpers