### PR TITLE
Load with Zeitwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     slack-ruby-block-kit (0.17.0)
+      zeitwerk (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
@@ -87,6 +88,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     unicode-display_width (2.1.0)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby

--- a/lib/slack-ruby-block-kit.rb
+++ b/lib/slack-ruby-block-kit.rb
@@ -1,3 +1,14 @@
 # frozen_string_literal: true
 
-require_relative './slack/block_kit'
+require 'zeitwerk'
+
+loader = Zeitwerk::Loader.new
+loader.tag = 'slack-ruby-block-kit'
+loader.push_dir(__dir__)
+loader.ignore(__FILE__)
+loader.inflector.inflect('version' => 'VERSION')
+loader.setup
+
+require 'slack/block_kit'
+
+loader.eager_load

--- a/lib/slack/block_kit.rb
+++ b/lib/slack/block_kit.rb
@@ -8,12 +8,6 @@ module Slack
 
     module Layout; end
 
-    Dir[File.join(__dir__, 'block_kit', 'composition', '*.rb')].sort.each { |file| require file }
-    Dir[File.join(__dir__, 'block_kit', 'element', '*.rb')].sort.each { |file| require file }
-    Dir[File.join(__dir__, 'block_kit', 'layout', '*.rb')].sort.each { |file| require file }
-    Dir[File.join(__dir__, 'block_kit', '*.rb')].sort.each { |file| require file }
-    Dir[File.join(__dir__, 'surfaces', '*.rb')].sort.each { |file| require file }
-
     module_function
 
     def blocks

--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative './section/multi_select_elements'
-
 module Slack
   module BlockKit
     module Layout

--- a/slack-ruby-block-kit.gemspec
+++ b/slack-ruby-block-kit.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'slack/block_kit/version'
+require_relative 'lib/slack/block_kit/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'slack-ruby-block-kit'
@@ -23,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }
+  spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,8 @@ SimpleCov.start do
   formatter SimpleCov::Formatter::Codecov if ENV['CI']
 end
 
-load 'slack/block_kit/version.rb'
 
-require 'slack/block_kit'
+require 'slack-ruby-block-kit'
 require 'pry'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Hi! As per our Twitter thread :).

This setup cannot be done with `for_gem` because that is just a simple helper that automates a few things for gems that satisfy certain conventions. However, you can always do it manually. The gem already follows naming conventions perfectly, so the setup is not a big deal.

The configuration is quite clear I think. We need to ignore `__FILE__` because it is already being loaded and does not define `SlackRubyBlockKit`. This is fine, it is only an entry point.

In `spec/spec_helper.rb` the patch replaces

```ruby
require 'slack/block_kit'
```

with

```ruby
require 'slack-ruby-block-kit'
```

because the is the documented entry point, and because the entry point defines the autoloader.

Then, my experience says it is better that `gemspec`s have as little side-effects as possible. The `gemspec` only needs the version, so just cherry-pick the version file.