### PR TITLE
Add video block support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.bundle/
+/.bundle
+/vendor/bundle
 /.yardoc
 /_yardoc/
 /coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- Added `Slack::BlockKit::Layout::Video` (#152 by @jcat4)
+
+This adds support for Slack's new Video Block.
+
+See: https://api.slack.com/reference/block-kit/blocks#video
 
 ### Changed
 - N/A

--- a/lib/slack/block_kit/blocks.rb
+++ b/lib/slack/block_kit/blocks.rb
@@ -55,6 +55,19 @@ module Slack
         append(block)
       end
 
+      def video(alt_text:, thumbnail_url:, video_url:, title:, description:, **optional_args)
+        block = Layout::Video.new(
+          alt_text:,
+          thumbnail_url:,
+          video_url:,
+          title:,
+          description:,
+          **optional_args
+        )
+
+        append(block)
+      end
+
       def section(block_id: nil)
         block = Layout::Section.new(block_id: block_id)
 

--- a/lib/slack/block_kit/layout/video.rb
+++ b/lib/slack/block_kit/layout/video.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Slack
+  module BlockKit
+    module Layout
+      # A video block is designed to embed videos in all app surfaces
+      # (e.g. link unfurls, messages, modals, App Home)  — anywhere you can put blocks!
+      # To use the video block within your app, you must have the links.embed:write scope.
+      #
+      # https://api.slack.com/reference/messaging/blocks#context
+      class Video
+        TYPE = 'video'
+
+        def initialize(alt_text:, thumbnail_url:, video_url:, title:, description:, **optional_args)
+          @alt_text = alt_text
+          @thumbnail_url = thumbnail_url
+          @video_url = video_url
+          @author_name = optional_args[:author_name]
+          @block_id = optional_args[:block_id]
+          @provider_icon_url = optional_args[:provider_icon_url]
+          @provider_name = optional_args[:provider_name]
+          @title_url = optional_args[:title_url]
+          @description = Composition::PlainText.new(
+            text: description,
+            emoji: optional_args[:emoji]
+          )
+          @title = Composition::PlainText.new(
+            text: title,
+            emoji: optional_args[:emoji]
+          )
+        end
+
+        def as_json(*)
+          {
+            type: TYPE,
+            alt_text: @alt_text,
+            thumbnail_url: @thumbnail_url,
+            video_url: @video_url,
+            author_name: @author_name,
+            block_id: @block_id,
+            provider_icon_url: @provider_icon_url,
+            provider_name: @provider_name,
+            title_url: @title_url,
+            description: @description.as_json,
+            title: @title.as_json,
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/slack/block_kit/blocks_spec.rb
+++ b/spec/lib/slack/block_kit/blocks_spec.rb
@@ -197,4 +197,45 @@ RSpec.describe Slack::BlockKit::Blocks do
       expect(instance.as_json).to eq expected_json
     end
   end
+
+  describe '#video' do
+    subject(:video) do
+      instance.video(
+        alt_text: 'video_alt_text',
+        thumbnail_url: 'https://git.io/JfvWK',
+        video_url: 'https://git.io/JfvWK',
+        title: 'title',
+        description: 'description',
+      )
+    end
+
+    let(:expected_json) do
+      [
+        {
+          type: 'video',
+          alt_text: 'video_alt_text',
+          thumbnail_url: 'https://git.io/JfvWK',
+          video_url: 'https://git.io/JfvWK',
+          title: {
+            type: 'plain_text',
+            text: 'title',
+          },
+          description: {
+            type: 'plain_text',
+            text: 'description',
+          }
+        }
+      ]
+    end
+
+    it 'returns self' do
+      expect(video).to be(instance)
+    end
+
+    it 'serialises a video block' do
+      video
+
+      expect(instance.as_json).to eq(expected_json)
+    end
+  end
 end

--- a/spec/lib/slack/block_kit/layout/video_spec.rb
+++ b/spec/lib/slack/block_kit/layout/video_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Slack::BlockKit::Layout::Video do
+  describe ".as_json" do
+    subject(:video_json) { instance.as_json }
+
+    context "when only required arguments are provided" do
+      let(:instance) do
+        described_class.new(
+          alt_text: '__ALT_TEXT__',
+          thumbnail_url: '__THUMBNAIL_URL__',
+          video_url: '__VIDEO_URL__',
+          title: '__TITLE__',
+          description: '__DESCRIPTION__'
+        )
+      end
+
+      it "correctly serializes arguments" do
+        expect(video_json).to eq({
+          type: 'video',
+          alt_text: '__ALT_TEXT__',
+          thumbnail_url: '__THUMBNAIL_URL__',
+          video_url: '__VIDEO_URL__',
+          title: {
+            type: "plain_text",
+            text: '__TITLE__',
+          },
+          description: {
+            type: "plain_text",
+            text: '__DESCRIPTION__',
+          }
+        })
+      end
+    end
+
+    context "when all arguments are provided" do
+      let(:instance) do
+        described_class.new(
+          alt_text: '__ALT_TEXT__',
+          thumbnail_url: '__THUMBNAIL_URL__',
+          video_url: '__VIDEO_URL__',
+          title: '__TITLE__',
+          description: '__DESCRIPTION__',
+          author_name: '__AUTHOR_NAME__',
+          block_id: '__BLOCK_ID__',
+          provider_icon_url: '__PROVIDER_ICON_URL__',
+          provider_name: '__PROVIDER_NAME__',
+          title_url: '__TITLE_URL__',
+          emoji: false
+        )
+      end
+
+      it "correctly serializes arguments" do
+        expect(video_json).to eq({
+          type: 'video',
+          alt_text: '__ALT_TEXT__',
+          thumbnail_url: '__THUMBNAIL_URL__',
+          video_url: '__VIDEO_URL__',
+          title: {
+            type: "plain_text",
+            text: '__TITLE__',
+            emoji: false,
+          },
+          description: {
+            type: "plain_text",
+            text: '__DESCRIPTION__',
+            emoji: false,
+          },
+          author_name: '__AUTHOR_NAME__',
+          block_id: '__BLOCK_ID__',
+          provider_icon_url: '__PROVIDER_ICON_URL__',
+          provider_name: '__PROVIDER_NAME__',
+          title_url: '__TITLE_URL__',
+        })
+      end
+    end
+  end
+
+end

--- a/spec/lib/slack/block_kit/layout/video_spec.rb
+++ b/spec/lib/slack/block_kit/layout/video_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Slack::BlockKit::Layout::Video do
-  describe ".as_json" do
+  describe '.as_json' do
     subject(:video_json) { instance.as_json }
 
-    context "when only required arguments are provided" do
+    context 'when only required arguments are provided' do
       let(:instance) do
         described_class.new(
           alt_text: '__ALT_TEXT__',
@@ -17,25 +17,25 @@ RSpec.describe Slack::BlockKit::Layout::Video do
         )
       end
 
-      it "correctly serializes arguments" do
+      it 'correctly serializes arguments' do
         expect(video_json).to eq({
           type: 'video',
           alt_text: '__ALT_TEXT__',
           thumbnail_url: '__THUMBNAIL_URL__',
           video_url: '__VIDEO_URL__',
           title: {
-            type: "plain_text",
+            type: 'plain_text',
             text: '__TITLE__',
           },
           description: {
-            type: "plain_text",
+            type: 'plain_text',
             text: '__DESCRIPTION__',
           }
         })
       end
     end
 
-    context "when all arguments are provided" do
+    context 'when all arguments are provided' do
       let(:instance) do
         described_class.new(
           alt_text: '__ALT_TEXT__',
@@ -52,19 +52,19 @@ RSpec.describe Slack::BlockKit::Layout::Video do
         )
       end
 
-      it "correctly serializes arguments" do
+      it 'correctly serializes arguments' do
         expect(video_json).to eq({
           type: 'video',
           alt_text: '__ALT_TEXT__',
           thumbnail_url: '__THUMBNAIL_URL__',
           video_url: '__VIDEO_URL__',
           title: {
-            type: "plain_text",
+            type: 'plain_text',
             text: '__TITLE__',
             emoji: false,
           },
           description: {
-            type: "plain_text",
+            type: 'plain_text',
             text: '__DESCRIPTION__',
             emoji: false,
           },


### PR DESCRIPTION
Closes #149

Since [there are so many fields](https://api.slack.com/reference/block-kit/blocks#video) on the video type, I've separated the required arguments into kwargs and packed everything else into a splatted `optional_args` hash.

I've made both `title` and `description` required arguments. The API docs _say_ that description is only preferred (not required), however, the API will fail with `[ERROR] must be more than 0 characters` if a blank/missing description is given. The same issue occurs unless I pass a title of one or more characters.

_I also added `/vendor/bundle` to .gitignore so users can use `bundle config set --local path 'vendor/bundle'`_