### PR TITLE
Allow "emoji" arg to be passed through to some constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- N/A
+- Added ability to set `emoji` property via `Slack::BlockKit::Blocks#input` (#175 by @bmorton)
+- Added ability to set `emoji` property via `Slack::BlockKit::Element::RadioButtons#option` (#175 by @bmorton)
 
 ### Changed
 - N/A

--- a/lib/slack/block_kit/blocks.rb
+++ b/lib/slack/block_kit/blocks.rb
@@ -76,13 +76,14 @@ module Slack
         append(block)
       end
 
-      def input(label:, hint: nil, block_id: nil, dispatch_action: nil, optional: nil)
+      def input(label:, hint: nil, block_id: nil, dispatch_action: nil, optional: nil, emoji: nil)
         block = Layout::Input.new(
           label: label,
           hint: hint,
           block_id: block_id,
           dispatch_action: dispatch_action,
-          optional: optional
+          optional: optional,
+          emoji: emoji
         )
 
         yield(block) if block_given?

--- a/lib/slack/block_kit/element/radio_buttons.rb
+++ b/lib/slack/block_kit/element/radio_buttons.rb
@@ -21,11 +21,12 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(value:, text:, initial: false)
+        def option(value:, text:, initial: false, emoji: nil)
           option = Composition::Option.new(
             value: value,
             text: text,
-            initial: initial
+            initial: initial,
+            emoji: emoji
           )
 
           @options << option

--- a/spec/lib/slack/block_kit/blocks_spec.rb
+++ b/spec/lib/slack/block_kit/blocks_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Slack::BlockKit::Blocks do
 
   describe '#input' do
     subject(:input) do
-      instance.input(label: 'input', hint: 'hint', block_id: '1123', optional: optional) do |i|
+      instance.input(label: 'input', hint: 'hint', block_id: '1123', optional: optional, emoji: true) do |i|
         i.plain_text_input(action_id: 'action')
       end
     end
@@ -120,8 +120,8 @@ RSpec.describe Slack::BlockKit::Blocks do
     let(:expected_json) do
       [
         { type: 'input',
-          hint: { text: 'hint', type: 'plain_text' },
-          label: { text: 'input', type: 'plain_text' },
+          hint: { text: 'hint', type: 'plain_text', emoji: true },
+          label: { text: 'input', type: 'plain_text', emoji: true },
           element: { action_id: 'action', type: 'plain_text_input' },
           block_id: '1123',
           optional: optional }

--- a/spec/lib/slack/block_kit/element/radio_buttons_spec.rb
+++ b/spec/lib/slack/block_kit/element/radio_buttons_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
               type: 'plain_text',
               text: 'Option 2'
             }
+          },
+          {
+            value: 'option-3',
+            text: {
+              type: 'plain_text',
+              text: 'Option 3',
+              emoji: true
+            }
           }
         ],
         initial_option: {
@@ -54,6 +62,7 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
     it 'correctly serializes' do
       instance.option(value: 'option-1', text: 'Option 1')
       instance.option(value: 'option-2', text: 'Option 2', initial: true)
+      instance.option(value: 'option-3', text: 'Option 3', initial: true, emoji: true)
       expect(as_json).to eq(expected_json)
     end
 


### PR DESCRIPTION
tl;dr I found a few places where passing through `emoji` helps make the DSL a bit easier to use.

Hey, thanks for this great gem!  We have an internal implementation of the Slack BlockKit spec in our app and I'm looking at swapping in this great, open-source library instead.  I've spiked out a replacement for our view handler and hooked it up to this BlockKit implementation so we can use it with ActionView.  I've also built a prototype of an importer that will convert BlockKit JSON into this gem's DSL that's embedded in our new view layer.

As part of this conversion work, I've been using the somewhat full-featured Builder examples to import and the way I'm auto-generating the code assumes that it can pass `emoji` through this way to make sure the imported JSON and the JSON that's generated by the view match.  Are you interested in this change?

Additionally, once I've got it deployed, I hope to be able to open source and share some of this if you think it'd be useful!  Would you be interested in either the ActionView template handler or the JSON->DSL converter as part of this library?  Or if I release it separately, could I get a mention in the README?  I'd love to team up, let me know!