### PR TITLE
Add description to additional elements

### DIFF
--- a/lib/slack/block_kit/composition/option_group.rb
+++ b/lib/slack/block_kit/composition/option_group.rb
@@ -17,8 +17,8 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(text:, value:, emoji: nil, initial: false)
-          @options << Option.new(text: text, value: value, emoji: emoji, initial: initial)
+        def option(text:, value:, description: nil, emoji: nil, initial: false)
+          @options << Option.new(text: text, value: value, description: description,  emoji: emoji, initial: initial)
 
           self
         end

--- a/lib/slack/block_kit/element/multi_static_select.rb
+++ b/lib/slack/block_kit/element/multi_static_select.rb
@@ -37,11 +37,12 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(value:, text:, initial: false, emoji: nil)
+        def option(value:, text:, description: nil, initial: false, emoji: nil)
           @options ||= []
           @options << Composition::Option.new(
             value: value,
             text: text,
+            description: description,
             emoji: emoji,
             initial: initial
           )

--- a/lib/slack/block_kit/element/radio_buttons.rb
+++ b/lib/slack/block_kit/element/radio_buttons.rb
@@ -21,10 +21,11 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(value:, text:, initial: false, emoji: nil)
+        def option(value:, text:, description: nil, initial: false, emoji: nil)
           option = Composition::Option.new(
             value: value,
             text: text,
+            description: description,
             initial: initial,
             emoji: emoji
           )

--- a/lib/slack/block_kit/element/static_select.rb
+++ b/lib/slack/block_kit/element/static_select.rb
@@ -27,11 +27,12 @@ module Slack
           yield(self) if block_given?
         end
 
-        def option(value:, text:, initial: false, emoji: nil)
+        def option(value:, text:, description: nil, initial: false, emoji: nil)
           @options ||= []
           @options << Composition::Option.new(
             value: value,
             text: text,
+            description: description,
             emoji: emoji,
             initial: initial
           )

--- a/spec/lib/slack/block_kit/composition/option_group_spec.rb
+++ b/spec/lib/slack/block_kit/composition/option_group_spec.rb
@@ -36,11 +36,25 @@ RSpec.describe Slack::BlockKit::Composition::OptionGroup do
       expect(instance.options.first).to be_initial
     end
 
+    it 'supports option descriptions' do
+      instance = described_class.new(label: 'hello')
+      instance.option(text: 'option', value: 'o', description: 'description text')
+
+      option_json = instance.options.first.as_json
+      expect(option_json[:description]).to eq(
+        { type: 'plain_text', text: 'description text' }
+      )
+    end
+
     it 'appends a Slack::BlockKit::Composition::Option object' do
       instance = described_class.new(label: 'hello')
-      expected = Slack::BlockKit::Composition::Option.new(text: 'option', value: 'o')
+      expected = Slack::BlockKit::Composition::Option.new(
+        text: 'option',
+        value: 'o',
+        description: 'description'
+      )
 
-      instance.option(text: 'option', value: 'o')
+      instance.option(text: 'option', value: 'o', description: 'description')
 
       expect(instance.options.last.as_json).to eq(expected.as_json)
     end
@@ -58,7 +72,15 @@ RSpec.describe Slack::BlockKit::Composition::OptionGroup do
       {
         label: Slack::BlockKit::Composition::PlainText.new(text: 'label', emoji: true).as_json,
         options: [
-          Slack::BlockKit::Composition::Option.new(text: 'text', value: 'value')
+          Slack::BlockKit::Composition::Option.new(
+            text: 'text',
+            value: 'value'
+          ),
+          Slack::BlockKit::Composition::Option.new(
+            text: 'text with description',
+            value: 'value2',
+            description: 'some description'
+          )
         ].map(&:as_json)
       }
     end
@@ -66,6 +88,11 @@ RSpec.describe Slack::BlockKit::Composition::OptionGroup do
     it 'correctly serializes' do
       instance = described_class.new(label: 'label', emoji: true) do |option_group|
         option_group.option(text: 'text', value: 'value')
+        option_group.option(
+          text: 'text with description',
+          value: 'value2',
+          description: 'some description'
+        )
       end
 
       expect(instance.as_json).to eq(expected)

--- a/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/multi_static_select_spec.rb
@@ -26,21 +26,33 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
               text: '__TEXT_1__',
               type: 'plain_text'
             },
-            value: '__VALUE_1__'
+            value: '__VALUE_1__',
+            description: {
+              type: 'plain_text',
+              text: '__DESCRIPTION_1__'
+            }
           },
           {
             text: {
               text: '__TEXT_2__',
               type: 'plain_text'
             },
-            value: '__VALUE_2__'
+            value: '__VALUE_2__',
+            description: {
+              type: 'plain_text',
+              text: '__DESCRIPTION_2__'
+            }
           },
           {
             text: {
               text: '__TEXT_3__',
               type: 'plain_text'
             },
-            value: '__VALUE_3__'
+            value: '__VALUE_3__',
+            description: {
+              type: 'plain_text',
+              text: '__DESCRIPTION_3__'
+            }
           }
         ]
       }
@@ -54,7 +66,11 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
           text: '__TEXT_2__',
           type: 'plain_text'
         },
-        value: '__VALUE_2__'
+        value: '__VALUE_2__',
+        description: {
+          type: 'plain_text',
+          text: '__DESCRIPTION_2__'
+        }
       }
     ]
   end
@@ -66,21 +82,33 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
           text: '__TEXT_1__',
           type: 'plain_text'
         },
-        value: '__VALUE_1__'
+        value: '__VALUE_1__',
+        description: {
+          type: 'plain_text',
+          text: '__DESCRIPTION_1__'
+        }
       },
       {
         text: {
           text: '__TEXT_2__',
           type: 'plain_text'
         },
-        value: '__VALUE_2__'
+        value: '__VALUE_2__',
+        description: {
+          type: 'plain_text',
+          text: '__DESCRIPTION_2__'
+        }
       },
       {
         text: {
           text: '__TEXT_3__',
           type: 'plain_text'
         },
-        value: '__VALUE_3__'
+        value: '__VALUE_3__',
+        description: {
+          type: 'plain_text',
+          text: '__DESCRIPTION_3__'
+        }
       }
     ]
   end
@@ -196,9 +224,9 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
     context 'with options' do
       subject(:as_json) do
-        instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
-        instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
-        instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+        instance.option(value: '__VALUE_1__', text: '__TEXT_1__', description: '__DESCRIPTION_1__')
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__')
+        instance.option(value: '__VALUE_3__', text: '__TEXT_3__', description: '__DESCRIPTION_3__')
         instance.as_json
       end
 
@@ -211,9 +239,9 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
 
     context 'with options and initial option' do
       subject(:as_json) do
-        instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
-        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', initial: true)
-        instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
+        instance.option(value: '__VALUE_1__', text: '__TEXT_1__', description: '__DESCRIPTION_1__')
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__', initial: true)
+        instance.option(value: '__VALUE_3__', text: '__TEXT_3__', description: '__DESCRIPTION_3__')
 
         instance.as_json
       end
@@ -231,9 +259,9 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     context 'with option_groups' do
       subject(:as_json) do
         instance.option_group(label: '__GROUP__') do |group|
-          group.option(value: '__VALUE_1__', text: '__TEXT_1__')
-          group.option(value: '__VALUE_2__', text: '__TEXT_2__')
-          group.option(value: '__VALUE_3__', text: '__TEXT_3__')
+          group.option(value: '__VALUE_1__', text: '__TEXT_1__', description: '__DESCRIPTION_1__')
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__')
+          group.option(value: '__VALUE_3__', text: '__TEXT_3__', description: '__DESCRIPTION_3__')
         end
         instance.as_json
       end
@@ -248,9 +276,9 @@ RSpec.describe Slack::BlockKit::Element::MultiStaticSelect do
     context 'with option_groups and initial option' do
       subject(:as_json) do
         instance.option_group(label: '__GROUP__') do |group|
-          group.option(value: '__VALUE_1__', text: '__TEXT_1__')
-          group.option(value: '__VALUE_2__', text: '__TEXT_2__', initial: true)
-          group.option(value: '__VALUE_3__', text: '__TEXT_3__')
+          group.option(value: '__VALUE_1__', text: '__TEXT_1__', description: '__DESCRIPTION_1__')
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__', initial: true)
+          group.option(value: '__VALUE_3__', text: '__TEXT_3__', description: '__DESCRIPTION_3__')
         end
 
         instance.as_json

--- a/spec/lib/slack/block_kit/element/radio_buttons_spec.rb
+++ b/spec/lib/slack/block_kit/element/radio_buttons_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
             text: {
               type: 'plain_text',
               text: 'Option 1'
+            },
+            description: {
+              type: 'plain_text',
+              text: 'Description 1'
             }
           },
           {
@@ -38,6 +42,10 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
             text: {
               type: 'plain_text',
               text: 'Option 2'
+            },
+            description: {
+              type: 'plain_text',
+              text: 'Description 2'
             }
           },
           {
@@ -45,6 +53,11 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
             text: {
               type: 'plain_text',
               text: 'Option 3',
+              emoji: true
+            },
+            description: {
+              type: 'plain_text',
+              text: 'Description 3',
               emoji: true
             }
           }
@@ -54,15 +67,19 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
           text: {
             type: 'plain_text',
             text: 'Option 2'
+          },
+          description: {
+            type: 'plain_text',
+            text: 'Description 2'
           }
         }
       }
     end
 
     it 'correctly serializes' do
-      instance.option(value: 'option-1', text: 'Option 1')
-      instance.option(value: 'option-2', text: 'Option 2', initial: true)
-      instance.option(value: 'option-3', text: 'Option 3', initial: true, emoji: true)
+      instance.option(value: 'option-1', text: 'Option 1', description: 'Description 1')
+      instance.option(value: 'option-2', text: 'Option 2', description: 'Description 2', initial: true)
+      instance.option(value: 'option-3', text: 'Option 3', description: 'Description 3', initial: true, emoji: true)
       expect(as_json).to eq(expected_json)
     end
 
@@ -99,6 +116,10 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
               text: {
                 type: 'plain_text',
                 text: 'Option 1'
+              },
+              description: {
+                type: 'plain_text',
+                text: 'Description 1'
               }
             }
           ],
@@ -124,7 +145,7 @@ RSpec.describe Slack::BlockKit::Element::RadioButtons do
       end
 
       before do
-        instance.option(value: 'option-1', text: 'Option 1')
+        instance.option(value: 'option-1', text: 'Option 1', description: 'Description 1')
         instance.confirmation_dialog do |confirm|
           confirm.title(text: '__CONFIRM_TITTLE__')
           confirm.plain_text(text: '__CONFIRM_TEXT__')

--- a/spec/lib/slack/block_kit/element/static_select_spec.rb
+++ b/spec/lib/slack/block_kit/element/static_select_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
               text: '__TEXT_2__',
               type: 'plain_text'
             },
+            description: {
+              type: 'plain_text',
+              text: '__DESCRIPTION_2__'
+            },
             value: '__VALUE_2__'
           },
           {
@@ -53,7 +57,11 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
         text: '__TEXT_2__',
         type: 'plain_text'
       },
-      value: '__VALUE_2__'
+      value: '__VALUE_2__',
+      description: {
+        type: 'plain_text',
+        text: '__DESCRIPTION_2__'
+      }
     }
   end
 
@@ -70,6 +78,10 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
         text: {
           text: '__TEXT_2__',
           type: 'plain_text'
+        },
+        description: {
+          type: 'plain_text',
+          text: '__DESCRIPTION_2__'
         },
         value: '__VALUE_2__'
       },
@@ -156,7 +168,7 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
     context 'with options' do
       subject(:as_json) do
         instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
-        instance.option(value: '__VALUE_2__', text: '__TEXT_2__')
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__')
         instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
         instance.as_json
       end
@@ -171,7 +183,7 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
     context 'with options and initial option' do
       subject(:as_json) do
         instance.option(value: '__VALUE_1__', text: '__TEXT_1__')
-        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', initial: true)
+        instance.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__', initial: true)
         instance.option(value: '__VALUE_3__', text: '__TEXT_3__')
 
         instance.as_json
@@ -188,7 +200,7 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
       subject(:as_json) do
         instance.option_group(label: '__GROUP__') do |group|
           group.option(value: '__VALUE_1__', text: '__TEXT_1__')
-          group.option(value: '__VALUE_2__', text: '__TEXT_2__')
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__')
           group.option(value: '__VALUE_3__', text: '__TEXT_3__')
         end
         instance.as_json
@@ -205,7 +217,7 @@ RSpec.describe Slack::BlockKit::Element::StaticSelect do
       subject(:as_json) do
         instance.option_group(label: '__GROUP__') do |group|
           group.option(value: '__VALUE_1__', text: '__TEXT_1__')
-          group.option(value: '__VALUE_2__', text: '__TEXT_2__', initial: true)
+          group.option(value: '__VALUE_2__', text: '__TEXT_2__', description: '__DESCRIPTION_2__', initial: true)
           group.option(value: '__VALUE_3__', text: '__TEXT_3__')
         end
 


### PR DESCRIPTION
This PR adds description support to elements that were previously missing it, as reported in #181. Specifically, it adds description functionality to:
- StaticSelect
- MultiStaticSelect
- RadioButtons

Additionally, while implementing this fix, I discovered and added description support to OptionGroup components, which was necessary for descriptions to work properly in elements using option groups.