### PR TITLE
Issue: number_input was not defined in Slack::BlockKit::Layout.Input

### DIFF
--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -218,22 +218,21 @@ module Slack
 
         def number_input(
           action_id:,
+          is_decimal_allowed: nil,
           placeholder: nil,
           initial_value: nil,
-          is_decimal_allowed: nil,
-          focus_on_load: nil,
-          dispatch_action_config: nil,
           min_value: nil,
-          max_value: nil
+          max_value: nil,
+          focus_on_load: nil,
         )
           @element = Element::NumberInput.new(
             action_id: action_id,
+            is_decimal_allowed: is_decimal_allowed,
             placeholder: placeholder,
             initial_value: initial_value,
-            is_decimal_allowed: is_decimal_allowed,
-            focus_on_load: focus_on_load,
             min_value: min_value,
             max_value: max_value
+            focus_on_load: focus_on_load,
           )
 
           self

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -223,7 +223,7 @@ module Slack
           initial_value: nil,
           min_value: nil,
           max_value: nil,
-          focus_on_load: nil,
+          focus_on_load: nil
         )
           @element = Element::NumberInput.new(
             action_id: action_id,

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -226,7 +226,7 @@ module Slack
           min_value: nil,
           max_value: nil
         )
-          @element = Element::PlainTextInput.new(
+          @element = Element::NumberInput.new(
             action_id: action_id,
             placeholder: placeholder,
             initial_value: initial_value,

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -231,7 +231,7 @@ module Slack
             placeholder: placeholder,
             initial_value: initial_value,
             min_value: min_value,
-            max_value: max_value
+            max_value: max_value,
             focus_on_load: focus_on_load
           )
 

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -216,6 +216,29 @@ module Slack
           self
         end
 
+        def number_input(
+          action_id:,
+          placeholder: nil,
+          initial_value: nil,
+          is_decimal_allowed: nil,
+          focus_on_load: nil,
+          dispatch_action_config: nil,
+          min_value: nil,
+          max_value: nil
+        )
+          @element = Element::PlainTextInput.new(
+            action_id: action_id,
+            placeholder: placeholder,
+            initial_value: initial_value,
+            is_decimal_allowed: is_decimal_allowed,
+            focus_on_load: focus_on_load,
+            min_value: min_value,
+            max_value: max_value
+          )
+
+          self
+        end
+
         def url_text_input(
           action_id:,
           placeholder: nil,

--- a/lib/slack/block_kit/layout/input.rb
+++ b/lib/slack/block_kit/layout/input.rb
@@ -232,7 +232,7 @@ module Slack
             initial_value: initial_value,
             min_value: min_value,
             max_value: max_value
-            focus_on_load: focus_on_load,
+            focus_on_load: focus_on_load
           )
 
           self


### PR DESCRIPTION
There was an issue when using a number_input as it was not defined in Slack::BlockKit::Layout.Input
