### PR TITLE
Exclude Gemfiles from packaged gem

### DIFF
--- a/slack-ruby-block-kit.gemspec
+++ b/slack-ruby-block-kit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`
       .split("\x0")
-      .reject { |f| f.match(%r{^(test|spec|features)/}) }
+      .reject { |f| f.start_with?('Gemfile') || f.match?(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.3'


### PR DESCRIPTION
Thank you for maintaining this gem.

This excludes `Gemfile*` from `spec.files`. The files remain tracked for development reproducibility, but are no longer included in the published gem.

Amazon Inspector recursively scans lockfiles in container images. In our case, the bundled lockfile produced the following finding even though this version was not part of the resolved dependency graph:

```json
{
  "vulnerabilityId": "CVE-2024-43398",
  "package": {
    "name": "rexml",
    "version": "3.2.8",
    "packageManager": "RUBY",
    "filePath": "/usr/local/bundle/ruby/3.4.0/gems/slack-ruby-block-kit-0.26.0/Gemfile.lock",
    "fixedInVersion": "3.3.6"
  }
}
```

Verified with RSpec, RuboCop, and by unpacking the built gem.